### PR TITLE
Tiller Documentation

### DIFF
--- a/docs/tiller.md
+++ b/docs/tiller.md
@@ -6,9 +6,8 @@ Note: Helm should be installed locally before running the below.
 $ brew install kubernetes-helm
 ```
 
-Steps:
-1. Clone the `ministryofjustice/kubernetes-investigations` repo 
-https://github.com/ministryofjustice/kubernetes-investigations
+**Steps:**
+1. Clone the [`ministryofjustice/kubernetes-investigations`](https://github.com/ministryofjustice/kubernetes-investigations) repository
 2. `$ kubectl apply -f ./cluster-components/helm/rbac-config.yml`
 3. `$ helm init --tiller-namespace kube-system --service-account tiller`
 

--- a/docs/tiller.md
+++ b/docs/tiller.md
@@ -1,0 +1,13 @@
+# HOW TO INSTALL TILLER ON A NEW CLUSTER
+
+Note: Helm should be installed locally before running the below.
+
+```
+$ brew install kubernetes-helm
+```
+
+Steps:
+1. Clone the `kubernetes-investigations` repo 
+2. `$ kubectl apply -f ./cluster-components/helm/rbac-config.yml`
+3. `$ helm init --tiller-namespace kube-system --service-account tiller`
+

--- a/docs/tiller.md
+++ b/docs/tiller.md
@@ -1,4 +1,4 @@
-# HOW TO INSTALL TILLER ON A NEW CLUSTER
+# How to install Tiller on a new cluster
 
 Note: Helm should be installed locally before running the below.
 
@@ -7,7 +7,8 @@ $ brew install kubernetes-helm
 ```
 
 Steps:
-1. Clone the `kubernetes-investigations` repo 
+1. Clone the `ministryofjustice/kubernetes-investigations` repo 
+https://github.com/ministryofjustice/kubernetes-investigations
 2. `$ kubectl apply -f ./cluster-components/helm/rbac-config.yml`
 3. `$ helm init --tiller-namespace kube-system --service-account tiller`
 


### PR DESCRIPTION
connects to #222 

**WHAT**
Documentation on how to install tiller on a new cluster.

**WHY**
As part of DR for laa-fee-calculator, a new cluster will need tiller to allow Helm to communicate with the Kubernetes API. 

Note: This method has not been tested during the ticket. Awaiting completion of #218 and #219 for a new cluster without tiller installed. However, this method has been documented before in https://github.com/ministryofjustice/kubernetes-investigations/blob/master/auth0/README.md and I have personally used this method to install tiller. 

This will be tested and changes will be made as required.