### PR TITLE
added Documentation for applying WebOps admin clusterRole

### DIFF
--- a/docs/Rbac.md
+++ b/docs/Rbac.md
@@ -1,0 +1,18 @@
+# How to install RBAC on a new cluster.
+
+## Purpose
+This document is to provide an instructions on applying the ClusterRole to the new cluster, this allows the webops team to have cluster wide permissions. 
+
+**Steps:**
+1. Clone the [`ministryofjustice/kubernetes-investigations`](https://github.com/ministryofjustice/kubernetes-investigations) repository
+2. `$ kubectl apply -f kubernetes-investigations/cluster-config/rbac/webops-cluster-admin.yml`
+3. `clusterrolebinding.rbac.authorization.k8s.io "webops-cluster-admin" created`
+
+
+
+
+
+
+
+
+

--- a/docs/Rbac.md
+++ b/docs/Rbac.md
@@ -4,8 +4,8 @@
 This document is to provide an instructions on applying the ClusterRole to the new cluster, this allows the webops team to have cluster wide permissions. 
 
 **Steps:**
-2. `$ kubectl apply -f kubernetes-investigations/cluster-config/rbac/webops-cluster-admin.yml`
-3. `clusterrolebinding.rbac.authorization.k8s.io "webops-cluster-admin" created`
+1. `$ kubectl apply -f kubernetes-investigations/cluster-config/rbac/webops-cluster-admin.yml`
+2. `clusterrolebinding.rbac.authorization.k8s.io "webops-cluster-admin" created`
 
 
 

--- a/docs/Rbac.md
+++ b/docs/Rbac.md
@@ -4,7 +4,6 @@
 This document is to provide an instructions on applying the ClusterRole to the new cluster, this allows the webops team to have cluster wide permissions. 
 
 **Steps:**
-1. Clone the [`ministryofjustice/kubernetes-investigations`](https://github.com/ministryofjustice/kubernetes-investigations) repository
 2. `$ kubectl apply -f kubernetes-investigations/cluster-config/rbac/webops-cluster-admin.yml`
 3. `clusterrolebinding.rbac.authorization.k8s.io "webops-cluster-admin" created`
 


### PR DESCRIPTION
*WHAT*  
Documentation on how to install WebOps ClusterRole.

*WHY*  
As part of DR for for the new cluster, we will need to apply the WebOps ClusterRole. This is the documentation on the steps involved.

Note: This doc is assuming all pre-requisites has been documented and repo has been cloned.
