### PR TITLE
Add Terraform RDS module to cloud-platform README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We have a series of repositories for our work that we have listed below. We have
 |-----------------|---------------|---------------------|
 | ECR credentials  | https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials | Terraform module which creates ECR credentials and repository on AWS. |
 | S3 bucket |  https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket | Terraform module that will create an S3 bucket and credentials in AWS. |
-| RDS instance | https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance | Terraform module that will create an RDS instance, KMS key, Database Subnet Group and credentials |
+| RDS instance | https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance | Terraform module that will create an RDS instance, KMS key, Database Subnet Group and credentials in AWS. |
 
 
 ## Other repos

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ We have a series of repositories for our work that we have listed below. We have
 |-----------------|---------------|---------------------|
 | ECR credentials  | https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials | Terraform module which creates ECR credentials and repository on AWS. |
 | S3 bucket |  https://github.com/ministryofjustice/cloud-platform-terraform-s3-bucket | Terraform module that will create an S3 bucket and credentials in AWS. |
+| RDS instance | https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance | Terraform module that will create an RDS instance, KMS key, Database Subnet Group and credentials |
 
 
 ## Other repos


### PR DESCRIPTION
connects to closed ticket ministryofjustice/cloud-platform#303

**WHAT**
- Add a link to RDS module under Terraform modules in README.md

**WHY**
To keep a record of the repos that the cloud platforms manage