### PR TITLE
Add section for impact on user docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/cloud-platform-story-template.md
+++ b/.github/ISSUE_TEMPLATE/cloud-platform-story-template.md
@@ -16,6 +16,10 @@ about: Create new Cloud Platform story
 
 <!-- Describe proposed approach -->
 
+## Which part of the user docs does this impact
+
+<!-- Describe which parts of the user docs might need updates or changes as part of this work -->
+
 ## Questions / Assumptions
 
 <!-- Additional information to explain approach taken -->
@@ -24,9 +28,10 @@ about: Create new Cloud Platform story
 
 <!-- Checklist for definition of done and acceptance criteria, for example: -->
 
-- [ ] must compile
-- [ ] must pass tests
-- [ ] must address all the steps of user journey
+- [ ] readme has been updated
+- [ ] user docs have been updated
+- [ ] another team member has reviewed
+- [ ] smoke tests are green
 
 ## Reference
 


### PR DESCRIPTION
We talked in retro about how we sometimes miss updating a doc as part of
the story we are completing. This prompt should help us consider the
imapct on the user docs when we are raising the story.

I've also changed the example checklist at the bottom to make it a
little more representative of what we do.