### PR TITLE
Format our architecture decision records (ADRs) as per other projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ board](https://waffle.io/ministryofjustice/cloud-platform).
 It's best to search our board before adding new Issues in an effort to
 reduce duplicates and encourage activity on existing conversations.
 
+## Links
+
+ * [Architecture Decision Records](architecture-decision-record)
+
 ## Cloud platform repo list
 
 We have a series of repositories for our work that we have listed below. We have adopted the naming convention of starting each repo with `cloud-platform-`. Where some repos have a similar purpose we try to name them similarly, (e.g. `cloud-platform-terraform-*` for terraform modules). We also try to [name things](https://ministryofjustice.github.io/technical-guidance/standards/naming-things/#naming-things) so that users can infer a basic understanding of what a given thing does from its name.

--- a/architecture-decision-record/000-Record-Architecture-Decisions.md
+++ b/architecture-decision-record/000-Record-Architecture-Decisions.md
@@ -1,0 +1,104 @@
+# 0. Record Architecture Decisions
+
+Date: 2019-05-01
+
+## Status
+
+✅ Accepted
+
+## Context
+
+During our work on the Cloud Platform, we will have to make architectural
+decisions about the platform and associated tools & processes.
+
+When making decisions, we should record them somewhere for future reference, to
+help us remember why we made them, and to help teams working in related areas
+understand why we made them.
+
+We should make our decisions public so that other teams can find them more
+easily, and because [making things open makes things
+better](https://www.gov.uk/guidance/government-design-principles#make-things-open-it-makes-things-better).
+
+## Decision
+
+We will use Architecture Decision Records, as described by Michael Nygard in
+[this
+article](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
+
+An architecture decision record is a short text file describing a single
+decision.
+
+We will keep ADRs in this public repository under decisions/[number]-[title].md
+
+We should use a lightweight text formatting language like Markdown.
+
+ADRs will be numbered sequentially and monotonically. Numbers will not be
+reused.
+
+If a decision is reversed, we will keep the old one around, but mark it as
+superseded. (It's still relevant to know that it was the decision, but is no
+longer the decision.)
+
+We will use a format with just a few parts, so each document is easy to digest:
+
+**Title** These documents have names that are short noun phrases. For example,
+"ADR 1: Record architectural decisions" or "ADR 9: Use Docker for deployment"
+
+**Status** A decision may be "proposed" if it's still under discussion, or
+"accepted" once it is agreed. If a later ADR changes or reverses a decision, it
+may be marked as "deprecated" or "superseded" with a reference to its
+replacement.
+
+**Context** This section describes the forces at play, including technological,
+political, social, and local to the service. These forces are probably in
+tension, and should be called out as such. The language in this section is
+value-neutral. It is simply describing facts.
+
+**Decision** This section describes our response to these forces. It is stated
+in full sentences, with active voice. "We will ..."
+
+**Consequences** This section describes the resulting context, after applying
+the decision. All consequences should be listed here, not just the "positive"
+ones. A particular decision may have positive, negative, and neutral
+consequences, but all of them affect the team and service in the future.
+
+The whole document should be one or two pages long. We will write each ADR as
+if it is a conversation with a future person joining the team. This requires
+good writing style, with full sentences organised into paragraphs. Bullets are
+acceptable only for visual style, not as an excuse for writing sentence
+fragments.
+
+[adr-tools](https://github.com/npryce/adr-tools) can help us work with our ADRs
+consistently.
+
+We will link to these ADRs from other documentation where relevant.
+
+## Consequences
+
+One ADR describes one significant decision for the service. It should be
+something that has an effect on how the rest of the service will run.
+
+Developers and service stakeholders (and anyone else who's interested) can see
+the ADRs, even as the team composition changes over time.
+
+The motivation behind previous decisions is visible for everyone, present and
+future. Nobody is left scratching their heads to understand, "What were they
+thinking?" and the time to change old decisions will be clear from changes in
+the service's context.
+
+Having a central place to record decisions which affect all of our work will
+make the sequence of decisions clear, and make it easier for us to refer back to
+decisions later on.
+
+This repo holds Architecture Decision Records, for the cloud platform team. We
+will be using the architecture decision record to help keep a record of what
+approaches we are currently taking to our infrastructure and to help our future
+selves understand why those decisions were made. The approach is described by
+Michael Nygard in [this
+article](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+Everyone can see the ADRs, even as the team composition changes over time. This
+means motivation behind previous decisions is visible for everyone, present and
+future. Nobody is left scratching their heads to understand, "What were they
+thinking?" and the time to change old decisions will be clear from changes in
+the project's context.

--- a/architecture-decision-record/README.md
+++ b/architecture-decision-record/README.md
@@ -6,6 +6,18 @@ Cloud Platform.
 To understand why we are recording decisions and how we are doing it, please
 see [ADR-000](000-Record-Architecture-Decisions.md)
 
+## Table of contents
+
+* ✅ [0. Record Architecture Decisions](000-Record-Architecture-Decisions.md)
+* ✅ [1. Use AWS hosted Elasticsearch](001-Use-AWS-hosted-elasticsearch.md)
+* ✅ [2. Use GitHub for architecture decision log](002-Use-github-for-architecture-decision-record.md)
+* ✅ [3. Use Concourse CI](003-Use-Concourse-CI.md)
+* ✅ [4. Use kubernetes for running containerised applications](004-use-kubernetes-for-container-management.md)
+* ✅ [5. Use GitHub as our identity provider](006-Use-github-as-user-directory.md)
+* ✅ [6. Use ECR As Container Registry](007-Use-ECR-As-Container-Registry.md)
+* ✅ [7. Support Deployments from Third Party CI](008-Support-Deployments-from-Third-Party-CI.md)
+* ✅ [8. Naming convention for clusters](009-Naming-convention-for-clusters.md)
+
 ### Statuses:
 
 * Proposed: 🤔

--- a/architecture-decision-record/README.md
+++ b/architecture-decision-record/README.md
@@ -1,32 +1,10 @@
-# Architecture decision record
+# Cloud Platform Architecture Decisions
 
-This repo holds Architecture Decision Records, for the cloud platform team. We will be using the architecture decision record to help keep a record of what approaches we are currently taking to our infrastructure and to help our future selves understand why those decisions were made. The approach is described by Michael Nygard in [this article](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+This is a record of architectural decisions made during the development of the
+Cloud Platform.
 
-Everyone can see the ADRs, even as the team composition changes over time. This means motivation behind previous decisions is visible for everyone, present and future. Nobody is left scratching their heads to understand, "What were they thinking?" and the time to change old decisions will be clear from changes in the project's context.
-
-## How it works
-
-An architecture decision record is a short text file describing a single decision. One ADR describes one significant decision for the project. It should be something that has an effect on how the rest of the project will run.
-
-We keep architecture decision records in this repo using a naming structure of the form `NNN-description-of-decision.md`. We use [markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) to format the records.
-
-If a decision is reversed, we keep the old one around, but mark it as superseded. (It's still relevant to know that it was the decision, but is no longer the decision.)
-
-## Format of a decision record
-
-We use a format with just a few parts, so each document is easy to digest. The format has just a few parts.
-
-**Title** These documents have names that are short noun phrases. For example, "ADR 1: Record architectural decisions" or "ADR 9: Use Docker for deployment"
-
-**Status** A decision may be "proposed" if the project stakeholders haven't agreed with it yet, or "accepted" once it is agreed. If a later ADR changes or reverses a decision, it may be marked as "deprecated" or "superseded" with a reference to its replacement.
-
-**Context** This section describes the forces at play, including technological, political, social, and project local. These forces are probably in tension, and should be called out as such. The language in this section is value-neutral. It is simply describing facts.
-
-**Decision** This section describes our response to these forces. It is stated in full sentences, with active voice. "We will ..."
-
-**Consequences** This section describes the resulting context, after applying the decision. All consequences should be listed here, not just the "positive" ones. A particular decision may have positive, negative, and neutral consequences, but all of them affect the team and project in the future.
-
-The whole document should be one or two pages long. We will write each ADR as if it is a conversation with a future person joining the team. This requires good writing style, with full sentences organised into paragraphs. Bullets are acceptable only for visual style, not as an excuse for writing sentence fragments.
+To understand why we are recording decisions and how we are doing it, please
+see [ADR-000](000-Record-Architecture-Decisions.md)
 
 ### Statuses:
 

--- a/architecture-decision-record/README.md
+++ b/architecture-decision-record/README.md
@@ -27,3 +27,11 @@ We use a format with just a few parts, so each document is easy to digest. The f
 **Consequences** This section describes the resulting context, after applying the decision. All consequences should be listed here, not just the "positive" ones. A particular decision may have positive, negative, and neutral consequences, but all of them affect the team and project in the future.
 
 The whole document should be one or two pages long. We will write each ADR as if it is a conversation with a future person joining the team. This requires good writing style, with full sentences organised into paragraphs. Bullets are acceptable only for visual style, not as an excuse for writing sentence fragments.
+
+### Statuses:
+
+* Proposed: 🤔
+* Accepted: ✅
+* Rejected: ❌
+* Superseded: ⌛️
+* Amended: ♻️


### PR DESCRIPTION
This PR also adds a link to the ADRs in a 'Links' section of the main repo. webpage.

You can view this change [here](https://github.com/ministryofjustice/cloud-platform/tree/adr-list)