### PR TITLE
Replace the link to our Waffle board with ZenHub (fixes #885)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # Ministry of Justice Cloud Platform Master Repo
-[![Waffle.io - Columns and their card
-count](https://badge.waffle.io/ministryofjustice/cloud-platform.svg?columns=all)](https://waffle.io/ministryofjustice/cloud-platform)
 
 ## About this Repository
 This is the MoJ Cloud Platform team's repository for public facing

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## About this Repository
 This is the MoJ Cloud Platform team's repository for public facing
-documentation, feature work, enhancements, and issues. Waffle users can add issues
-through GitHub Issues or directly on our [Waffle
-board](https://waffle.io/ministryofjustice/cloud-platform).
+documentation, feature work, enhancements, and issues. ZenHub users can add issues
+through GitHub Issues or directly on our [ZenHub
+board](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/board)
 
 It's best to search our board before adding new Issues in an effort to
 reduce duplicates and encourage activity on existing conversations.


### PR DESCRIPTION
Updated version visible [here](https://github.com/ministryofjustice/cloud-platform/tree/replace-waffle)