### PR TITLE
Only git push if runbooks were changed

### DIFF
--- a/runbooks/bin/publish
+++ b/runbooks/bin/publish
@@ -32,7 +32,13 @@ commit_and_push() {
   git add .
   git add -u .
   git commit -m "Update with latest changes"
-  git push
+  if [ $? -eq 0 ]; then
+    git push
+  else
+    # ensure we exit with no error, if there were no
+    # runbook changes
+    true
+  fi
 }
 
 main


### PR DESCRIPTION
If the current commit to the cloud-platform repo does not affect
the runbooks directory, then if the last thing this script does
is to try and 'git push', the command will fail, and the overall
exit status of the script will be an error.

This will show as a build failure on CircleCI, which is
inappropriate, since it doesn't indicate an error at all - just
that nothing in the runbooks was affected by the current commit.

This change does not try to `git push` if the previous `git commit`
failed. In that case, the last thing this script does is execute
`true`, so there should not be a build failure in CircleCI.