### PR TITLE
Fix the 'GitHub' link at top-right of the guide

### DIFF
--- a/runbooks/config/tech-docs.yml
+++ b/runbooks/config/tech-docs.yml
@@ -12,7 +12,7 @@ header_links:
   'Feedback / Report a problem': 'mailto:platforms+runbooks@digital.justice.gov.uk?subject=Runbooks+feedback'
 
   Documentation: /
-  GitHub: https://github.com/ministryofjustice/cloud-platform/runbooks
+  GitHub: https://github.com/ministryofjustice/cloud-platform/tree/master/runbooks
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.
 enable_search: true


### PR DESCRIPTION
The current link renders a 404 page.