### PR TITLE
Clarify cluster name for 'kops delete cluster'

### DIFF
--- a/runbooks/source/delete-cluster.html.md.erb
+++ b/runbooks/source/delete-cluster.html.md.erb
@@ -28,7 +28,7 @@ Then run the following `kops` command (this will not delete the cluster).
 Append it with `--yes` to confirm deletion.
 
 ```
-$ kops delete cluster --name <clusterName>
+$ kops delete cluster --name <clusterName>.cloud-platform.service.justice.gov.uk
 ```
 
 Change directories and perform the following, destroying the cluster essentials.


### PR DESCRIPTION
In the runbook to create a cluster, the cluster name is always the
'short name' but for this step in the cluster delete process, we
need to use the full name of the cluster, as reported by
`kops get clusters`