### PR TITLE
Add a warning about kubernetes context

### DIFF
--- a/runbooks/source/create-cluster.html.md.erb
+++ b/runbooks/source/create-cluster.html.md.erb
@@ -27,7 +27,7 @@ You can get the auth0 values from the `terraform-provider-auth0` application on 
 
 ## Run the build script
 
-> WARNING: Be aware that this script uses the kubernetes config defined on **your machine**, when applying the `cloud-platform-components` terraform files. So, if you have started this script and then used a different terminal to do some other work, it is very easy to forget about the build script and switch your kubernetes context to point to the live cluster. **This can break parts of the production environment.**
+> WARNING: Be aware that this script uses the kubernetes context defined on **your machine**, when applying the `cloud-platform-components` terraform files. So, if you have started this script and then used a different terminal to do some other work, it is very easy to forget about the build script and switch your kubernetes context to point to the live cluster. **This can break parts of the production environment.**
 
 Start from the root directory of a working copy of the [infrastructure repo].
 

--- a/runbooks/source/create-cluster.html.md.erb
+++ b/runbooks/source/create-cluster.html.md.erb
@@ -27,6 +27,8 @@ You can get the auth0 values from the `terraform-provider-auth0` application on 
 
 ## Run the build script
 
+> WARNING: Be aware that this script uses the kubernetes config defined on **your machine**, when applying the `cloud-platform-components` terraform files. So, if you have started this script and then used a different terminal to do some other work, it is very easy to forget about the build script and switch your kubernetes context to point to the live cluster. **This can break parts of the production environment.**
+
 Start from the root directory of a working copy of the [infrastructure repo].
 
 Execute the script, supplying the desired name of your new cluster. e.g.:


### PR DESCRIPTION
When building a cluster, it is easy to accidentally switch
kubernetes context in a different terminal, which could cause the
build script to make changes in our production platform.

This commit adds a warning to try and prevent this from happening.

<img width="847" alt="Screen Shot 2019-07-03 at 13 17 46" src="https://user-images.githubusercontent.com/2338/60590866-fd2fce00-9d94-11e9-86a2-dad0ff6dc1de.png">
