### PR TITLE
Add section on alerts to "create-cluster" runbook

### DIFF
--- a/runbooks/source/create-cluster.html.md.erb
+++ b/runbooks/source/create-cluster.html.md.erb
@@ -60,6 +60,62 @@ Kubernetes master is running at https://api.david-test1.cloud-platform.service.j
 KubeDNS is running at https://api.david-test1.cloud-platform.service.justice.gov.uk/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
 ```
 
+## Disable Alerts
+
+By default, your test cluster will send alerts to the team slack channels. This can cause confusion if the work that you're doing on the test cluster involves something which, in the live cluster, would be a critical component.
+
+The simplest way to disable alerts is to prevent them from reaching [PagerDuty], by removing the token for our PagerDuty account.
+
+#### Edit the file `terraform/cloud-platform-components/terraform.tfvars`
+
+Find the line `pagerduty_config = "--------- SOME VALUE ----------"`, and replace the value with a dummy value (not empty string), then save the file.
+
+#### Ensure your terraform workspace and kubernetes context are pointing at your test cluster
+
+```bash
+cd terraform/cloud-platform-components
+terraform workspace list
+```
+
+If you are not targeting your test cluster workspace, run
+
+```bash
+terraform workspace select [your cluster]
+```
+
+Check your kubernetes context by running
+
+```bash
+kubectl cluster-info
+```
+
+The output should be
+
+```bash
+Kubernetes master is running at https://api.XXXXXXX.cloud-platform.service.justice.gov.uk
+KubeDNS is running at https://api.XXXXXXX.cloud-platform.service.justice.gov.uk/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+```
+
+...where `XXXXXXX` is the name of your test cluster.
+
+If your context is pointing at live-1, switch to your test cluster by running
+
+```bash
+kops export kubecfg XXXXXXX.cloud-platform.service.justice.gov.uk
+```
+
+#### Apply the change
+
+When you are confident that both your terraform workspace and kubernetes context are set to your test cluster, apply the change to set the pagerduty config value:
+
+```bash
+terraform apply -target=helm_release.prometheus_operator
+```
+
+Answer `yes` if the planned changes look correct.
+
+This should leave all the alerting infrastructure of your test cluster intact, but prevent any generated alerts from reaching PagerDuty (and being routed from there to Slack, or anywhere else).
+
 [infrastructure repo]: https://github.com/ministryofjustice/cloud-platform-infrastructure
 [auth0 provider instructions]: https://github.com/yieldr/terraform-provider-auth0#using-the-provider
 [cluster naming policy]: https://github.com/ministryofjustice/cloud-platform/blob/master/architecture-decision-record/009-Naming-convention-for-clusters.md
@@ -68,3 +124,4 @@ KubeDNS is running at https://api.david-test1.cloud-platform.service.justice.gov
 [AWS CLI]: https://aws.amazon.com/cli/
 [ruby]: https://www.ruby-lang.org/
 [docker]: https://www.docker.com/
+[PagerDuty]: https://www.pagerduty.com/


### PR DESCRIPTION
This describes a procedure for safely silencing
alerts from test clusters, so that they don't
create misleading noise in our alerts slack
channels.