### PR TITLE
move on-call to run book

### DIFF
--- a/runbooks/source/on-call.html.md.erb
+++ b/runbooks/source/on-call.html.md.erb
@@ -1,0 +1,98 @@
+---
+title: Going on call
+weight: 9150
+---
+
+# Going on call
+
+What’s expected?
+
+## Expected:
+
+* Carry out [well-defined sensible actions](https://dsdmoj.atlassian.net/wiki/spaces/PLAT/pages/297533847/Run+Books) in response to critical incidents.
+
+* Understand how to carry out those actions, and what they do.
+
+* Verify access ahead of time to various systems and interfaces required to carry out these actions.
+
+* Getting set up to access production is quite involved if you don’t work on the service you’re supporting, so it’s worth making sure you’ve done so ahead of time.
+
+## Not Expected:
+
+* Take heroic actions and be able to solve any out-of-hours critical event single handedly.
+
+* Have very detailed knowledge of every nuance of every MOJ Digital service.
+
+* Carrying out risky activities or take judgement calls beyond your comfort zone without support.
+
+## Where do I start?
+
+### 1/ Do two rotations on in-hours second line.
+
+### 2/ Get production access to supported services.
+
+### 3/ Get access to our on-call tools:
+
+* [Pingdom](https://my.pingdom.com/)
+
+* [Pagerduty](https://moj-digital-tools.pagerduty.com/) (and configure your contact details and notifications, this is the single source of truth for when you are on call.)
+
+* [AWS](https://mojdsd.signin.aws.amazon.com/)
+
+* the MOJDS VPN (and configure it to “send all traffic over VPN connection”)
+
+### 4/ Do a dry-run of an incident.
+
+### 5/ Get on the on-call rota.
+
+### 6/ Log your hours.
+
+## What do I get for being on call?
+
+* 15% of day rate for every 8 hours that you’re on call out of standard working hours. This payment is simply for being on call.
+
+* 1/8 of day rate for each full hour actively worked while on call.
+
+Civil servant equivalent of day rate is base salary / 230
+
+## Civil servants - SOP Claim
+
+### 1/ Get a DOM1 account  (you should be given one as soon as Shared Services have registered your joining, or ask your local HR people)
+
+### 2/ Log into a DOM1 machine and access SOP using the shortcut on your desktop, and log in.
+
+### 3/ Navigate to Employee Self-Service > Individual Compensation Distribution (ICD)
+
+### 4/ Select drop-down menu for On-call without pensionable amount
+
+### 5/ Add the amount claimed for in the box provided
+
+### 6/ Click “Continue”, check the details, add notes in the comment section about the weeks being claimed, and then click “Submit”
+
+### 7/ If your claim is submitted before the 8th (or so) of the month, you’ll get it paid in that month’s payroll. If it’s after that, it’ll be in the next month’s.
+
+## Civil servants - SOP Problem Resolution
+
+### 1/ Take a screenshot of the claim submission problem.
+
+### 2/ Navigate to Employee Self-Service > Others > Form Submission
+
+### 3/ Select problem area by pressing the magnifying glass icon and pressing “Go”.
+
+### 4/ Add comments describing the problem.
+
+### 5/ After clicking “Next”, “Add Attachment” to add the screenshot and click “Submit”
+
+# Contractors
+
+The exact process might depend upon which supplier you are through. Some (or maybe all, we haven’t worked out yet) supplier systems don’t cope with trying to bill more than 5 days worth in a week (Specifically Hays fall in to this category).
+
+If you are not working on a normal work day (Monday–Friday) then you can use this to bill
+
+### 1/ Ask your contact at the supplier to set you up on Fieldglass for overtime.
+
+### 2 /Log your time
+
+* ??? Log the overtime (More detail once someone has actually done this successfully); or
+
+* If you are billing a ‘work day’ in lieu note this in a comment in the timesheet

--- a/runbooks/source/on-call.html.md.erb
+++ b/runbooks/source/on-call.html.md.erb
@@ -83,7 +83,7 @@ Civil servant equivalent of day rate is base salary / 230
 
 ### 5/ After clicking “Next”, “Add Attachment” to add the screenshot and click “Submit”
 
-# Contractors
+## Contractors
 
 The exact process might depend upon which supplier you are through. Some (or maybe all, we haven’t worked out yet) supplier systems don’t cope with trying to bill more than 5 days worth in a week (Specifically Hays fall in to this category).
 


### PR DESCRIPTION
why ticket "Decommission Opsmanual and legacy Cloud Platforms Confluence Pages#687"
https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/687

Note this is the first stage - purely moving it across to a run-book:
        - We will need to review the content in light of our new procedures (but I think this ticket is purely to move across relevant things from the opsmanual/confluence pages (there is a lot of content there)
        -  There is a link "run books" that is still to a confluence page (that in itself needs moving across)  
