### PR TITLE
Update cluster build process to reflect changes

### DIFF
--- a/runbooks/source/create-cluster.html.md.erb
+++ b/runbooks/source/create-cluster.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Create a new cluster
 weight: 50
-last_reviewed_on: 2019-09-10
+last_reviewed_on: 2019-10-07
 review_in: 3 months
 ---
 
@@ -48,36 +48,41 @@ See our [cluster naming policy] for information on how to choose a suitable name
 The script takes around 30 minutes to execute. At the end, you should see output like this:
 
 ```
+Run options: exclude {:cluster=>"live-1"}
+..........................
+
+Finished in 4 minutes 53.4 seconds (files took 4.54 seconds to load)
+26 examples, 0 failures
+
+2019-10-07 09:07:49 kubectl cluster-info
 Kubernetes master is running at https://api.david-test1.cloud-platform.service.justice.gov.uk
 KubeDNS is running at https://api.david-test1.cloud-platform.service.justice.gov.uk/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+
+To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
 ```
 
-## Disable Alerts
+The section before `kubectl cluster-info` is the cluster integration tests, which run at the end of the build
+process. The number of tests will increase, so the output will vary from what is shown here.
 
-By default, your test cluster will send alerts to the team slack channels. This can cause confusion if the work that you're doing on the test cluster involves something which, in the live cluster, would be a critical component.
+Each dot in the line represents a passing test. If any tests fail, you will see more output explaining
+the nature of the failure.
 
-### High Priority Alerts
+Any test failures could indicate a problem with your test cluster, which will need to be resolved before you
+can confidently use it for anything.
 
-The simplest way to disable high-priority alerts is to prevent them from reaching [PagerDuty], by removing the token for our PagerDuty account.
+## Alerts
 
-#### Edit the file `terraform/cloud-platform-components/terraform.tfvars`
+The build script replaces the webhook values in the source code with dummy values, to prevent
+alerts from test clusters from showing up in the team slack channels.
 
-Find the line `pagerduty_config = "--------- SOME VALUE ----------"`, and replace the value with a dummy value (not empty string), then save the file.
+If you want to reverse this, you need to revert the changes to these files, and then do a `terraform apply`:
 
-
-### Lower priority alerts
-
-Low-priority alerts are sent directly to the `#lower-priority-alarms` slack channel, so the procedure for disabling them is slightly different.
-
-#### Edit the file `terraform/cloud-platform-components/terraform.tfvars`
-
-Look for the `alertmanager_slack_receivers` section, and find the entry whose `channel` value is `#lower-priority-alarms`.
-
-Change the value of `webhook` and replace the string after the last `/` in the URL with a dummy value, then save the file.
+* high priority alerts: `terraform/cloud-platform-components/terraform.tfvars` (look for `pagerduty_config`)
+* lower priority alerts: `terraform/cloud-platform-components/terraform.tfvars` (look for `alertmanager_slack_receivers`)
 
 ### Apply the changes
 
-Finally, we will use terraform to apply the changes to the prometheus operator in your test cluster.
+Use terraform to apply the changes to the prometheus operator in your test cluster.
 
 #### Ensure your terraform workspace and kubernetes context are pointing at your test cluster
 
@@ -120,8 +125,6 @@ terraform apply -target=helm_release.prometheus_operator
 ```
 
 Answer `yes` if the planned changes look correct.
-
-This should leave all the alerting infrastructure of your test cluster intact, but prevent any high-priority alerts from reaching PagerDuty (and being routed from there to Slack, or anywhere else).
 
 [infrastructure repo]: https://github.com/ministryofjustice/cloud-platform-infrastructure
 [cluster naming policy]: https://github.com/ministryofjustice/cloud-platform/blob/master/architecture-decision-record/009-Naming-convention-for-clusters.md


### PR DESCRIPTION
* Add the integration test output to the example
* Explain the integration test output
* Remove description of how to disable alerts

The build script automatically disables alerts, so
this is no longer needed.

* Explain how to reinstate alerts, if necessary
* Update the last reviewed date