### PR TITLE
Update the 'manually delete namespace' runbook

### DIFF
--- a/runbooks/source/manually-delete-namespace-resources.html.md.erb
+++ b/runbooks/source/manually-delete-namespace-resources.html.md.erb
@@ -39,9 +39,10 @@ export PIPELINE_CLUSTER=live-1.cloud-platform.service.justice.gov.uk
 export PIPELINE_STATE_BUCKET=cloud-platform-terraform-state
 export PIPELINE_STATE_KEY_PREFIX="cloud-platform-environments/"
 export PIPELINE_STATE_REGION="eu-west-1"
-export PIPELINE_CLUSTER_STATE_BUCKET=cloud-platform-terraform-state
-export PIPELINE_CLUSTER_STATE_KEY_PREFIX="cloud-platform/"
 export PIPELINE_TERRAFORM_STATE_LOCK_TABLE=cloud-platform-environments-terraform-lock
+export TF_VAR_cluster_name: "live-1"
+export TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
+export TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
 export cluster=live-1.cloud-platform.service.justice.gov.uk
 ```
 
@@ -70,10 +71,7 @@ terraform init \
 ## Run `terraform destroy`
 
 ```
-tf destroy \
-  -var="cluster_name=${cluster%%.*}" \
-  -var="cluster_state_bucket=${PIPELINE_CLUSTER_STATE_BUCKET}" \
-  -var="cluster_state_key=${PIPELINE_CLUSTER_STATE_KEY_PREFIX}${cluster%%.*}/terraform.tfstate"
+tf destroy
 ```
 
 After confirming that you're happy with the proposed changes, all the


### PR DESCRIPTION
The pipeline has changed in order to be compatible
with terraform 0.12, see:

https://github.com/ministryofjustice/cloud-platform-concourse/pull/128
https://github.com/ministryofjustice/cloud-platform-concourse/pull/130

This change updates the runbook to keep the
instructions correct by:

* Setting TF_VAR_xxx environment variables instead
of passing variables as command-line arguments
* Removing environment variables which are no
longer used