### PR TITLE
Add a `make tools-shell` step, deleting cluster

### DIFF
--- a/runbooks/source/delete-cluster.html.md.erb
+++ b/runbooks/source/delete-cluster.html.md.erb
@@ -25,6 +25,7 @@ There is a [destroy-cluster.sh] script which you can use to delete your cluster.
 > The script is entirely non-interactive, and will not prompt you to confirm anything. It just destroys things.
 
 * Edit the script to change the value of `CLUSTER` to your test cluster
+* Run `make tools-shell`
 * Run the script: `./destroy-cluster.sh`
 
 If any steps fail:


### PR DESCRIPTION
Running the destroy script inside a shell on the tools image is
safer, because it provides a separate, dedicated kubernetes
context for the `kubectl` commands.

This means, if the user switches context in another terminal
window, they won't accidentally be running commands targeting
the wrong cluster (if their delete process is still running)