### PR TITLE
Fix on call guide header structure

### DIFF
--- a/runbooks/source/on-call.html.md.erb
+++ b/runbooks/source/on-call.html.md.erb
@@ -7,16 +7,16 @@ review_in: 3 months
 
 # Going on call
 
-What’s expected?
+## What’s expected?
 
-## Expected:
+### Expected:
 
 * Carry out [well-defined sensible actions](https://dsdmoj.atlassian.net/wiki/spaces/PLAT/pages/297533847/Run+Books) in response to critical incidents.
 * Understand how to carry out those actions, and what they do.
 * Verify access ahead of time to various systems and interfaces required to carry out these actions.
 * Getting set up to access production is quite involved if you don’t work on the service you’re supporting, so it’s worth making sure you’ve done so ahead of time.
 
-## Not Expected:
+### Not Expected:
 
 * Take heroic actions and be able to solve any out-of-hours critical event single handedly.
 * Have very detailed knowledge of every nuance of every MOJ Digital service.


### PR DESCRIPTION
“What's expected” here is clearly supposed to be a header, but isn't. This fixes that, and brings the expectation headers under it.

This probably should have been included in #1496, but I didn't spot it till after that was merged.