### PR TITLE
Bump review date of the runbooks index page

### DIFF
--- a/runbooks/source/index.html.md.erb
+++ b/runbooks/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Cloud Platform Runbooks
 weight: 1
-last_reviewed_on: 2019-09-10
+last_reviewed_on: 2019-12-10
 review_in: 3 months
 ---
 


### PR DESCRIPTION
This removes the red "out of date" warning message.