### PR TITLE
New fork: Kuberos

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ We have a series of repositories for our work that we have listed below. We have
 | Custom error pages | https://github.com/ministryofjustice/cloud-platform-custom-error-pages | Docker image which serves custom error pages (e.g. for 404 errors) |
 | Namespace usage report | https://github.com/ministryofjustice/cloud-platform-namespace-usage-report | Web application to show cluster namespace usage charts |
 | Helm Chart Repository | https://github.com/ministryofjustice/cloud-platform-helm-charts | Helm Chart repository to store internal helm charts used by the platform  |
+| Kuberos | https://github.com/ministryofjustice/cloud-platform-kuberos | Kuberos fork that Cloud Platform team mantain |
 
 [rds-port-forward]: https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance#access-outside-the-cluster
 [environments repository]: https://github.com/ministryofjustice/cloud-platform-environments

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ We have a series of repositories for our work that we have listed below. We have
 | Custom error pages | https://github.com/ministryofjustice/cloud-platform-custom-error-pages | Docker image which serves custom error pages (e.g. for 404 errors) |
 | Namespace usage report | https://github.com/ministryofjustice/cloud-platform-namespace-usage-report | Web application to show cluster namespace usage charts |
 | Helm Chart Repository | https://github.com/ministryofjustice/cloud-platform-helm-charts | Helm Chart repository to store internal helm charts used by the platform  |
-| Kuberos | https://github.com/ministryofjustice/cloud-platform-kuberos | Kuberos fork that Cloud Platform team mantain |
+| Kuberos | https://github.com/ministryofjustice/cloud-platform-kuberos | Kuberos fork that Cloud Platform team maintain |
 
 [rds-port-forward]: https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance#access-outside-the-cluster
 [environments repository]: https://github.com/ministryofjustice/cloud-platform-environments


### PR DESCRIPTION
Kuberos is deprecated project and we had to fork it in order to update the Alpine image and solve TLS problems like:

```
kuberos: error: cannot create OIDC provider from issuer https://justice-cloud-platform.eu.auth0.com/: Get https://justice-cloud-platform.eu.auth0.com/.well-known/openid-configuration: net/http: TLS handshake timeout
```