### PR TITLE
Add ops-log runbook including first entry

### DIFF
--- a/runbooks/source/ops-log.html.md.erb
+++ b/runbooks/source/ops-log.html.md.erb
@@ -1,0 +1,22 @@
+---
+title: Ops Log
+weight: 45
+last_reviewed_on: 2020-03-05
+review_in: 3 months
+---
+
+# Ops Log
+
+## February 2020
+
+### Cluster upgrade on 2020-02-28 07:00 UTC
+
+- **Status**: Complete at 2020-02-28 10:40 UTC
+
+- **Upgrade**: The Cloud Platform Live-1 cluster (production) was upgraded. The following components were upgraded:
+Kops 1.13.2 -> Kops 1.14.1
+Kubernetes 1.13.12 -> 1.14.10
+
+- **Changes**:
+[AMI and component changes](
+https://github.com/ministryofjustice/cloud-platform-infrastructure/commit/a4ea51d2e6e35886e3335f0f7d6f7bfaa2acd66b)

--- a/runbooks/source/ops-log.html.md.erb
+++ b/runbooks/source/ops-log.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Ops Log
-weight: 45
+weight: 48
 last_reviewed_on: 2020-03-05
 review_in: 3 months
 ---


### PR DESCRIPTION
The first entry is the Kubernetes upgrade in early Febuary. 

This PR closes https://github.com/ministryofjustice/cloud-platform/issues/1095