### PR TITLE
Fix the "View Source" link on runbooks pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
 
         # Build the user guide
       - run: mkdir runbooks/compiled || true
+      - run: cd runbooks; bin/add_source_url
       - run: cd runbooks; bundle exec middleman build --build-dir compiled
 
         # Replace compiled/.nojekyll (which gets deleted during the build process) so github knows we're

--- a/runbooks/bin/add_source_url
+++ b/runbooks/bin/add_source_url
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+# Script to add a "source_url" to the frontmatter of all runbook source files.
+# This makes the "View Source" link at the bottom of each published page work
+# correctly (which it doesn't by default, because the middleman site is in the
+# "runbooks" sub-directory of the repo, not root directory.  This script is
+# invoked during the publishing process, as defined in .circleci/config.yml
+
+SOURCE_URL_BASE = "https://github.com/ministryofjustice/cloud-platform/blob/master/runbooks"
+
+# Add a line to the frontmatter section of a source file NB: this will break if
+# the first line of the file is not the "---\n" that marks the beginning of the
+# frontmatter.
+def add_frontmatter(file, line)
+  lines = File.readlines(file)
+  head, *tail = lines
+  lines = [head, "#{line}\n"] + tail
+  File.write(file, lines.join(""))
+end
+
+Dir["source/**/*.html.md.erb"].each do |file|
+  url = [SOURCE_URL_BASE, file].join("/")
+  frontmatter_line = "source_url: #{url}"
+  add_frontmatter(file, frontmatter_line)
+end


### PR DESCRIPTION
Because the middleman site for the runbooks is in
the "runbooks" sub-directory of this repo, the 
"View Source" links at the bottom of each compiled
page don't work. 

e.g. the link points to:

https://github.com/ministryofjustice/cloud-platform/blob/master/source/upgrade-cluster.html.md.erb

...when it should point to:

https://github.com/ministryofjustice/cloud-platform/blob/master/runbooks/source/upgrade-cluster.html.md.erb

(i.e. "master" -> "master/runbooks")

This commit adds a script which inserts the
correct URL as the "source_url" frontmatter data
item for every page, before the HTML files are
compiled. Then the GDS tech-docs gem will use that
field as the target of the "View Source" link on
the compiled page.