### PR TITLE
convert AWS GuardDuty ReadMe to a runbook

### DIFF
--- a/runbooks/source/aws-guardduty.html.md.erb
+++ b/runbooks/source/aws-guardduty.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: AWS GuardDuty Information /How to Implement
-weight: 100
+weight: 130
 last_reviewed_on: 2020-03-17
 review_in: 3 months
 ---
@@ -9,7 +9,7 @@ review_in: 3 months
   
 ## Introduction
 
-Amazon GuardDuty is a continuous security monitoring service that analyzes and processes the following data sources:
+[Amazon GuardDuty](https://docs.aws.amazon.com/guardduty/index.html) is a continuous security monitoring service that analyzes and processes the following data sources:
 
 * VPC Flow Logs
 * AWS CloudTrail event logs
@@ -19,10 +19,23 @@ It uses threat intelligence feeds, such as:
 
 * lists of malicious IPs
 * lists of malicious domains
-* machine learning to identify unexpected and potentially unauthorized and malicious activity within your AWS environment. This can include issues like escalations of privileges, uses of exposed credentials, or communication with malicious IPs, URLs, or domains. For example, GuardDuty can detect compromised EC2 instances serving malware or mining bitcoin.
+* machine learning to identify unexpected and potentially unauthorized and malicious activity within your AWS environment. 
+
+GuardDuty informs you of the status of your AWS environment by producing security [findings](https://eu-west-2.console.aws.amazon.com/guardduty/home?region=eu-west-2#/findings?macros=current) that you can be viewed in the GuardDuty console or through Amazon CloudWatch events.
+
+GuardDuty findings include issues like escalations of privileges, uses of exposed credentials, or communication with malicious IPs, URLs, or domains. For example, GuardDuty can detect compromised EC2 instances serving malware or mining bitcoin.
+
 It also monitors AWS account access behavior for signs of compromise, such as unauthorized infrastructure deployments, like instances deployed in a region that has never been used, or unusual API calls, like a password policy change to reduce password strength.
 
-GuardDuty informs you of the status of your AWS environment by producing security findings that you can be viewed in the GuardDuty console or through Amazon CloudWatch events.
+###AWS GuardDuty Accounts
+
+* [Master Account](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_accounts.html#guardduty_master)
+
+A designated account that can configure GuardDuty as well as view and manage GuardDuty findings for its own account and all associated member accounts.
+
+* [Member Accounts](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_accounts.html#guardduty_member)
+
+Invited (by Master Account) to enable GuardDuty and become associated with the Master AWS account (once an invitation has been accepted).
 
 ## Our Current setup
 
@@ -31,29 +44,34 @@ Our setup at the moment is as follows:
 * There are at present two master accounts - both in the moj-cp AWS account:
 
 	*  One set up in the London AWS region 
-		*  at present this has no member AWS linked accounts. It is mainly for our cloud-platform live-1 AWS resources 
+		*  This is for our cloud-platform live-1 AWS resources [moj-cp -London region](https://eu-west-2.console.aws.amazon.com/guardduty/home?region=eu-west-2#/findings?macros=current)
 	*  One set up in the Ireland AWS region 
-		*  this controls several member AWS linked accounts. It is mainly for template-deploy related member accounts.
+		*  this controls several member AWS linked accounts. It is mainly for template-deploy related [member accounts](https://eu-west-1.console.aws.amazon.com/guardduty/home?region=eu-west-1#/linked-accounts).
 	
-* Global alert/findings will be picked up for Global AWS resources (i.e IAM, S3 etc) in both master accounts. 
-* Whereas alerts/findings for specific regional AWS resources (i.e ec2, vpc etc) will go to the relevant master account. 
-* All member account AWS alerts/findings will be channeled through their linked master account (at present in Ireland AWS region)  
+### AWS GuardDuty Findings for live-1 AWS resources
+ 
+* Findings that AWS GuardDuty reports for Global AWS resources/services (i.e IAM, S3 etc) are found in the AWS GuardDuty Findings dashboard master account in the Ireland AWS region. 
+* Findings that AWS GuardDuty reports for specific regional AWS resources/services (i.e ec2, vpc etc) are found in the master account AWS GuardDuty Findings dashboard in the London AWS region. 
+
+### AWS GuardDuty Findings for AWS member account resources
+
+* Findings that AWS GuardDuty reports for  AWS member accounts appear in the AWS GuardDuty Findings dashboard for the relevant member (in that AWS account) and are collated in the master account (Ireland AWS region)  
 
 Any findings in GuardDuty are sent to Cloudwatch event rules that then integrate with AWS SNS (Simple Notification Service) topics and subscriptions. These are alerted to Pagerduty (presently 'in office hours') and then onto slack channels (at the moment #lower-priority-alarms)
 
 Please see [AWS GuardDuty](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_settingup.html) regarding setting up AWS GuardDuty.
 
-Also see here [Aws Cloudwatch Frequently Asked Questions](https://aws.amazon.com/guardduty/faqs/) where most general information regarding this service can be found
+Also see here [AWS Cloudwatch frequently asked questions](https://aws.amazon.com/guardduty/faqs/) where most general information regarding this service can be found
 
-Please also see [terraform aws GuardDuty detector ](https://www.terraform.io/docs/providers/aws/r/guardduty_detector.html) regarding setting up the config (here) for terraform GuardDuty detector
+Please also see [terraform AWS GuardDuty detector ](https://www.terraform.io/docs/providers/aws/r/guardduty_detector.html) regarding setting up the config (here) for terraform AWS GuardDuty detector
 
 ## Table of contents
-  - [1 Prerequisite files](#1-prerequisite-files)
-  - [2 Adding a new member account](#2-adding-a-new-member-account)
-  - [3 Applying the terraform changes](#3-applying-the-terraform-changes)
-  - [4 Pagerduty to Slack integration](#4-pagerduty-to-slack-integration)
+  - [1. Prerequisite files](#1-prerequisite-files)
+  - [2. Adding a new member account](#2-adding-a-new-member-account)
+  - [3. Applying the terraform changes](#3-applying-the-terraform-changes)
+  - [4. Pagerduty to Slack integration](#4-pagerduty-to-slack-integration)
 
-### 1 Prerequisite files
+### 1. Prerequisite files
 
   - [Main Configuration File](#main-configuration-file) (guardduty.tf)
   - [Terraform Variables File](#terraform-variables-file) (terraform.tfvars)
@@ -63,7 +81,7 @@ Please also see [terraform aws GuardDuty detector ](https://www.terraform.io/doc
 
 #### Main Configuration File
 
-'guardduty.tf' contains code for the following config:
+['guardduty.tf'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/global-resources/guardduty.tf) contains code for the following config:
 
 * Enabling and turning GuardDuty on for the master account.
 * Enabling and turning GuardDuty on for the member account.
@@ -76,7 +94,7 @@ Please also see [terraform aws GuardDuty detector ](https://www.terraform.io/doc
 
 #### Terraform Variables File
 
-'terraform.tfvars' contains code for the following config variables:
+['terraform.tfvars'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/global-resources/terraform.tfvars) contains code for the following config variables:
 
 * aws_region
 * aws_profile for the master and member accounts (set locally in ~/.aws/credentials). This is set up using format "moj-[account] (see terraform.tfvars file)
@@ -88,7 +106,7 @@ Please also see [terraform aws GuardDuty detector ](https://www.terraform.io/doc
 * member_email (the email to which the initial invitation email(s) should be sent {from the master account} when setting up GuardDuty on the member account - this must match email used to set up the root account)
 #### AWS Cloudwatch Event Rules File
 
-'event-pattern.json'
+['event-pattern.json'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/global-resources/resources/event-pattern.json)
 
 * A json object that is used by 'AWS Cloudwatch Event Rules' and related 'Targets' to select 'AWS Guardduty Events' (findings) and route them to the AWS sns targets.
 
@@ -142,18 +160,18 @@ Example (high priority):
 
 #### Trusted ip List File
 
-'iplist.txt'
+['iplist.txt'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/global-resources/resources/iplist.txt)
 
 * A trusted ip list. GuardDuty does not generate findings for IP addresses that are included in this trusted IP list/s
 At this point in time terraform is unable to update this list by 'terraform apply'. The list has to be manually deleted in the AWS dashboard >  Guardduty > Lists > Trusted IP Lists. Then you can run the 'terraform apply.
 
 #### Variables Initialisation File
 
-'variables.tf'
+['variables.tf'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/global-resources/variables.tf)
 
 * Used to set up the terraform variables and defaults required by terraform 'guardduty.tf'
 
-### 2 Adding a new member account
+### 2. Adding a new member account
 
 * guardduty.tf add the following (incrementing the member no as required):
 
@@ -210,7 +228,7 @@ member7_email = "[root email address at time of account creation]"
 * In AWS member account Dashboard go to GuardDuty link > Accounts > Accept the invite
 This will add GuardDuty in the member account. Fidings will now also appear in the GuardDuty master accounty.
 
-### 3 Applying the terraform changes
+### 3. Applying the terraform changes
 
 ```
 terraform init
@@ -231,7 +249,7 @@ If the above is not possible - due to the AWS account having already been delete
 	terraform state rm aws_guardduty_detector.member....
 	terraform state rm aws_guardduty_member.member....  
 
-### 4 Pagerduty to Slack integration
+### 4. Pagerduty to Slack integration
 
 This is is also set up utilising terraform separately config here:
 

--- a/runbooks/source/aws-guardduty.html.md.erb
+++ b/runbooks/source/aws-guardduty.html.md.erb
@@ -1,0 +1,239 @@
+---
+title: AWS GuardDuty Information /How to Implement
+weight: 100
+last_reviewed_on: 2020-03-17
+review_in: 3 months
+---
+
+# AWS GuardDuty utilising Terraform
+  
+## Introduction
+
+Amazon GuardDuty is a continuous security monitoring service that analyzes and processes the following data sources:
+
+* VPC Flow Logs
+* AWS CloudTrail event logs
+* DNS logs.
+
+It uses threat intelligence feeds, such as:
+
+* lists of malicious IPs
+* lists of malicious domains
+* machine learning to identify unexpected and potentially unauthorized and malicious activity within your AWS environment. This can include issues like escalations of privileges, uses of exposed credentials, or communication with malicious IPs, URLs, or domains. For example, GuardDuty can detect compromised EC2 instances serving malware or mining bitcoin.
+It also monitors AWS account access behavior for signs of compromise, such as unauthorized infrastructure deployments, like instances deployed in a region that has never been used, or unusual API calls, like a password policy change to reduce password strength.
+
+GuardDuty informs you of the status of your AWS environment by producing security findings that you can be viewed in the GuardDuty console or through Amazon CloudWatch events.
+
+## Our Current setup
+
+Our setup at the moment is as follows:
+
+* There are at present two master accounts - both in the moj-cp AWS account:
+
+	*  One set up in the London AWS region 
+		*  at present this has no member AWS linked accounts. It is mainly for our cloud-platform live-1 AWS resources 
+	*  One set up in the Ireland AWS region 
+		*  this controls several member AWS linked accounts. It is mainly for template-deploy related member accounts.
+	
+* Global alert/findings will be picked up for Global AWS resources (i.e IAM, S3 etc) in both master accounts. 
+* Whereas alerts/findings for specific regional AWS resources (i.e ec2, vpc etc) will go to the relevant master account. 
+* All member account AWS alerts/findings will be channeled through their linked master account (at present in Ireland AWS region)  
+
+Any findings in GuardDuty are sent to Cloudwatch event rules that then integrate with AWS SNS (Simple Notification Service) topics and subscriptions. These are alerted to Pagerduty (presently 'in office hours') and then onto slack channels (at the moment #lower-priority-alarms)
+
+Please see [AWS GuardDuty](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_settingup.html) regarding setting up AWS GuardDuty.
+
+Also see here [Aws Cloudwatch Frequently Asked Questions](https://aws.amazon.com/guardduty/faqs/) where most general information regarding this service can be found
+
+Please also see [terraform aws GuardDuty detector ](https://www.terraform.io/docs/providers/aws/r/guardduty_detector.html) regarding setting up the config (here) for terraform GuardDuty detector
+
+## Table of contents
+  - [1 Prerequisite files](#1-prerequisite-files)
+  - [2 Adding a new member account](#2-adding-a-new-member-account)
+  - [3 Applying the terraform changes](#3-applying-the-terraform-changes)
+  - [4 Pagerduty to Slack integration](#4-pagerduty-to-slack-integration)
+
+### 1 Prerequisite files
+
+  - [Main Configuration File](#main-configuration-file) (guardduty.tf)
+  - [Terraform Variables File](#terraform-variables-file) (terraform.tfvars)
+  - [AWS Cloudwatch Event Rules File](#aws-cloudwatch-event-rules-file) (event-pattern.json)
+  - [Trusted ip List File](#trusted-ip-list-file)  (iplist.txt)
+  - [Variables Initialisation File](#variables-initialisation-file) (variables.tf)
+
+#### Main Configuration File
+
+'guardduty.tf' contains code for the following config:
+
+* Enabling and turning GuardDuty on for the master account.
+* Enabling and turning GuardDuty on for the member account.
+* Setting up the S3 bucket and then adding trusted IP ranges etc to its contents.
+* On the master account - setting up the iam group with the appropriate iam policies, allowing the setup, configuration and use of GuardDuty. Also allowing full access to the contents of the security bucket.
+* On the master account - Adding chosen iam users to the iam groups so that they have admin permissions to set up and use GuardDuty..
+* On the master account -Setting up AWS Cloudwatch Event rules to integrate with 'AWS GuardDuty Findings' and config to alert to the relevant AWS sns topic (and thence onto pagerduty)
+.Also to set up an event pattern (json file).
+* On the master account Setting up the relevant GuardDuty AWS SNS (Simple Notification Service) topic and subscription.
+
+#### Terraform Variables File
+
+'terraform.tfvars' contains code for the following config variables:
+
+* aws_region
+* aws_profile for the master and member accounts (set locally in ~/.aws/credentials). This is set up using format "moj-[account] (see terraform.tfvars file)
+* aws_account_id (the id for the master and member aws accounts)
+* integration_key (the Amazon-GuardDuty service integration key configured in pagerduty to integrate with AWS Guardduty)
+* users (admin aws iam  users)
+* topic_arn = "arn:aws:sns:eu-west-1:[aws-account-id]:GuardDuty-notifications" (this is how it will be configured as an aws sns (simple notification service) topic
+* endpoint  = ``` https://events.pagerduty.com/integration/[pagerduty to AWS Guardduty integraion_key]/enqueue ``` this is required by the sns subscription endpoint configuration)
+* member_email (the email to which the initial invitation email(s) should be sent {from the master account} when setting up GuardDuty on the member account - this must match email used to set up the root account)
+#### AWS Cloudwatch Event Rules File
+
+'event-pattern.json'
+
+* A json object that is used by 'AWS Cloudwatch Event Rules' and related 'Targets' to select 'AWS Guardduty Events' (findings) and route them to the AWS sns targets.
+
+When raising the actual finding in an AWS account, GuardDuty normalizes the raised finding to have one of three integer values. See [AWS Findings](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings.html#guardduty_filter-findings) for further information: 
+
+*   Severity Rating/ScoreRange: Value for Raised Findings
+	*   Low (0.1-3.9): 2
+	*   Medium (4.0-6.9): 5
+	*   HIGH (7.0-8.9): 8
+	*   (9.0 - 10.0) - NA (Reserved by AWS and NOT Implemented for any active findings)
+
+The json file should be configured accordingly:
+Example (high priority):
+
+```
+{
+  "detail-type": [
+    "GuardDuty Finding"
+  ],
+  "source": [
+    "aws.guardduty"
+  ],
+    "detail": {
+      "severity": [
+        7,
+        7.0,
+        7.1,
+        7.2,
+        7.3,
+        7.4,
+        7.5,
+        7.6,
+        7.7,
+        7.8,
+        7.9,
+        8,
+        8.0,
+        8.1,
+        8.2,
+        8.3,
+        8.4,
+        8.5,
+        8.6,
+        8.7,
+        8.8,
+        8.9
+      ]
+    }
+  }
+```
+
+#### Trusted ip List File
+
+'iplist.txt'
+
+* A trusted ip list. GuardDuty does not generate findings for IP addresses that are included in this trusted IP list/s
+At this point in time terraform is unable to update this list by 'terraform apply'. The list has to be manually deleted in the AWS dashboard >  Guardduty > Lists > Trusted IP Lists. Then you can run the 'terraform apply.
+
+#### Variables Initialisation File
+
+'variables.tf'
+
+* Used to set up the terraform variables and defaults required by terraform 'guardduty.tf'
+
+### 2 Adding a new member account
+
+* guardduty.tf add the following (incrementing the member no as required):
+
+```
+# -----------------------------------------------------------
+# membership7 account provider
+# -----------------------------------------------------------
+
+provider "aws.member7" {
+  region  = "${var.aws_region}"
+  profile = "${var.aws_member7_profile}"
+}
+
+# -----------------------------------------------------------
+# membership7 account GuardDuty detector
+# -----------------------------------------------------------
+
+resource "aws_guardduty_detector" "member7" {
+  provider = "aws.member7"
+
+  enable                       = true
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
+}
+
+# -----------------------------------------------------------
+# membership7 account GuardDuty member
+# -----------------------------------------------------------
+
+resource "aws_guardduty_member" "member7" {
+  account_id         = "${aws_guardduty_detector.member7.account_id}"
+  detector_id        = "${aws_guardduty_detector.master.id}"
+  email              = "${var.member7_email}"
+  invite             = true
+  invitation_message = "please accept guardduty invitation"
+}
+```
+
+* variable.tf add the following (incrementing the memmber no as required):
+
+```
+variable "aws_member7_account_id" {}
+variable "aws_member7_profile" {}
+variable "member7_email" {}
+```
+
+* terraform.tfvars add the following (incrementing the member no as required):
+
+```
+aws_member7_profile = "moj-[account name]"
+aws_member7_account_id = "[aws account id]"
+member7_email = "[root email address at time of account creation]"
+```
+
+* In AWS member account Dashboard go to GuardDuty link > Accounts > Accept the invite
+This will add GuardDuty in the member account. Fidings will now also appear in the GuardDuty master accounty.
+
+### 3 Applying the terraform changes
+
+```
+terraform init
+terraform plan
+terraform apply (answer 'yes' to actually update remote config)
+```
+
+* As at 16/03/2020 there was a problem where an actual AWS account had been removed/deactivated (and credentials no longer worked) - that related to a GuardDuty membership account.
+
+If possible to alleviate this problem - take the following action in the following order (before the AWS account is actually deactivated/deleted:
+
+*  remove 'resource "aws_guardduty_detector" "member...."' - terraform apply
+*  remove 'resource "aws_guardduty_member" "member...."'   - terraform apply
+*  then delete/deactivate the actual AWS account
+
+If the above is not possible - due to the AWS account having already been deleted then:
+
+	terraform state rm aws_guardduty_detector.member....
+	terraform state rm aws_guardduty_member.member....  
+
+### 4 Pagerduty to Slack integration
+
+This is is also set up utilising terraform separately config here:
+
+* https://github.com/ministryofjustice/cloudplatforms-terraform-ops/blob/master/main.tf
+* https://github.com/ministryofjustice/cloudplatforms-terraform-ops/blob/master/services/amazon-guardduty-notifications/pagerduty.tf


### PR DESCRIPTION
I have purely uplifted the existing GuardDutyREADME.md (https://github.com/ministryofjustice/cloud-platform-infrastructure/terraform/global-resources/docs/GuardDutyREADME.md) and turned it into a runbook - adding some instructions from having carried out  the pr to implement GuardDuty in the London AWS region)

why:
https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/1683

See also:
https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/629