### PR TITLE
Explain how to backup the remote kops state

### DIFF
--- a/runbooks/source/running-kops-update-rollingupdate.html.md.erb
+++ b/runbooks/source/running-kops-update-rollingupdate.html.md.erb
@@ -97,6 +97,8 @@ aws s3 cp --recursive $KOPS_STATE_STORE/live-1.cloud-platform.service.justice.go
 
 This takes a couple of minutes. At time of writing, this was around 10G of data (mostly etcd backup tarballs).
   
+> While the backup exists, `kops get clusters` will report "live-1" *twice*. This doesn't do any harm, but you do need to delete the backup in order to resolve this, either via the `aws` CLI too, or using the AWS web interface for S3.
+  
 #### Updating the remote kops state
 
 To apply your local changes to the kops state stored on S3:

--- a/runbooks/source/running-kops-update-rollingupdate.html.md.erb
+++ b/runbooks/source/running-kops-update-rollingupdate.html.md.erb
@@ -86,6 +86,18 @@ At this point, you should have an updated `kops/[cluster name].yaml` file in you
 Commit and push your changes, including those in the terraform source and template files.
 
 ### Applying local changes to the kops state store
+  
+#### Backup the remote kops state
+  
+If you want to preserve a backup of the current kops state on S3, you can do so like this:
+  
+```bash
+aws s3 cp --recursive $KOPS_STATE_STORE/live-1.cloud-platform.service.justice.gov.uk $KOPS_STATE_STORE/live-1-backup
+```
+
+This takes a couple of minutes. At time of writing, this was around 10G of data (mostly etcd backup tarballs).
+  
+#### Updating the remote kops state
 
 To apply your local changes to the kops state stored on S3:
 


### PR DESCRIPTION
This should allow reverting to the previous kops state, if there is a problem after doing `kops replace...`