### PR TITLE
Fix links to gandi.net

### DIFF
--- a/runbooks/source/manual-ssl-certificate-processes.html.md.erb
+++ b/runbooks/source/manual-ssl-certificate-processes.html.md.erb
@@ -17,18 +17,18 @@ There are 3 categories of certificate we use at Ministry of Justice:
 
 Where at all practicable we should be looking to utilise automated certificate management. The MoJ Hosting Service is looking at strategy to move consumers to modern certificate management solutions.
 
-This process specifically relates to certificates issued through [Gandi.net](gandi.net)
+This process specifically relates to certificates issued through [Gandi.net]
 
 ## Pre-requisites
 
 Before you begin, there are a few pre-requisites:
 
-* A user account for [Gandi.net](Gandi.net)
-* Access to the the [Certificates Google group](mailto:certificates@digital.justice.gov.uk) 
+* A user account for [Gandi.net]
+* Access to the the [Certificates Google group](mailto:certificates@digital.justice.gov.uk)
 * Access to the [Certificate Alerts Google group](mailto:certificate_alerts@digital.justice.gov.uk)
 * Access to mojdsd Route53
 
-Please contact your [administrator](mailto:certificates@digital.justice.gov.uk) to set these up. 
+Please contact your [administrator](mailto:certificates@digital.justice.gov.uk) to set these up.
 
 ## Requesting a new certificate via Gandi.net
 
@@ -64,7 +64,7 @@ We will review the list of Gandi.net certificates and identify any that require 
 
 Certificates will expire automatically if not renewed. If a certificate doesn’t require renewal you can leave the certificate to expire and no further action is required. You’ll receive a notification to the Certificate Alerts confirming expiry.
 
-If a certificate needs to be revoked before the expiry date then this can be done via [Gandi.net](https://docs.gandi.net/en/ssl/revoke/index.html). 
+If a certificate needs to be revoked before the expiry date then this can be done via [Gandi.net](https://docs.gandi.net/en/ssl/revoke/index.html).
 
 **Note that once a certificate has expired or been revoked it cannot be reinstated. If a certificate is required the process to request a new certificate should be followed.**
 
@@ -76,10 +76,4 @@ MoJ has a prepaid account with Gandi.net for paying for certificates.
 
 If the account runs low a notification is sent to Certificate Alerts. If that happens contact [Software Asset Management](mailto:SoftwareAssetManagement@justice.gov.uk) to arrange a top-up on the account.
 
-
-
-
-
-
-
-
+[gandi.net]: https://gandi.net


### PR DESCRIPTION
Links were specified like this:
```
[Gandi.net](gandi.net)
```
This is incorrect, and results in a link target of
```
https://..runbooks.../gandi.net
```

