### PR TITLE
Update disaster-recovery

### DIFF
--- a/runbooks/source/disaster-recovery.html.md.erb
+++ b/runbooks/source/disaster-recovery.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Cloud Platform Disaster Recovery
 weight: 90
-last_reviewed_on: 2019-09-10
+last_reviewed_on: 2020-05-11
 review_in: 3 months
 ---
 
@@ -630,7 +630,7 @@ This issue is due to old master IPs being set as endpoints in the kubernetes ser
 [kops-repo]: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/kops
 [etcd-managet-ctl]: https://github.com/kopeio/etcd-manager/releases/
 [etcd-manager-restore]: https://github.com/kopeio/etcd-manager/blob/master/docs/backup-restore.md
-[kops-backup-restore]: https://github.com/kubernetes/kops/blob/master/docs/etcd/backup-restore.md
+[kops-backup-restore]: https://github.com/kubernetes/kops/blob/master/docs/operations/etcd_backup_restore_encryption.md
 [apply-cloud-platform]: disaster-recovery.html#apply-cloud-platform-resources
 [create-a-new-cluster]: disaster-recovery.html#create-a-new-cluster
 [perform-the-restore]: disaster-recovery.html#perform-the-restore


### PR DESCRIPTION
Update disaster-recovery review date.

From the document below, restore process though etcd is still the same.

`https://github.com/kubernetes/kops/blob/master/docs/operations/etcd_backup_restore_encryption.md`

