### PR TITLE
Runbook describing how to make s3 bucket public

### DIFF
--- a/runbooks/source/public-s3-bucket.html.md.erb
+++ b/runbooks/source/public-s3-bucket.html.md.erb
@@ -1,0 +1,19 @@
+---
+title: Make an S3 bucket public
+weight: 150
+last_reviewed_on: 2020-06-09
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+This [lambda function] created by the security team runs weekly, and revokes public access for all our S3 Buckets.
+
+The lambda function has a `S3_EXCEPTION` environment variable which stores a list of S3 buckets to ignore. To enable public access to a bucket, it must be added to this list.
+
+The easiest way to do this is to [edit the environment variable] directly via the aws console.
+
+The function uses a substring test to see if the current bucket name appears in the `S3_EXCEPTION` string, so you can use any separator you want when you add the new bucket name to the variable.
+
+[lambda function]: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/cloudformation/aws-account-baseline-templates/aws-s3-enable-encryption-block-public-access
+[edit the environment variable]: https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/S3BucketBlockPublicAccess?tab=configuration


### PR DESCRIPTION
This runbook explains how to add an S3 bucket to the exception list, so
that the scheduled security function doesn't revert it to being private
if it has public access enabled.

related to https://github.com/ministryofjustice/cloud-platform/issues/1425