### PR TITLE
Publish to gh pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     docker:
       # This docker image is created from the Dockerfile in
       # this repository.
-      - image: ministryofjustice/cloud-platform-runbooks:1.6
+      - image: ministryofjustice/cloud-platform-runbooks:1.7
 
     working_directory: ~/repo
 

--- a/runbooks/bin/publish
+++ b/runbooks/bin/publish
@@ -25,7 +25,7 @@ clone_github_pages_repo() {
 
 copy_compiled_files() {
   # This script is executed from the root folder of the cloud-platform repo
-  cp -r runbooks/compiled/* cloud-platform-runbooks/docs/
+  cp -r runbooks/compiled/* cloud-platform-runbooks/
 }
 
 commit_and_push() {

--- a/runbooks/makefile
+++ b/runbooks/makefile
@@ -1,5 +1,5 @@
 IMAGE := ministryofjustice/cloud-platform-runbooks
-VERSION := 1.6 # Change this in .circleci/config.yml if you update it here
+VERSION := 1.7 # Change this in .circleci/config.yml if you update it here
 
 .built-docker-image: Dockerfile Gemfile Gemfile.lock
 	docker build -t $(IMAGE) .


### PR DESCRIPTION
Push the compiled runbooks documentation files to the "gh-pages" branch of the "cloud-platform-runbooks" repository, not to "master/docs"