### PR TITLE
Use a github action to build the publisher image

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,0 +1,21 @@
+name: Publish docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push image to docker hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Build and push publisher image to docker hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          path: runbooks
+          repository: ministryofjustice/cloud-platform-runbooks
+          tag_with_ref: true

--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -4,4 +4,11 @@ This directory contains the source files for the runbooks hosted at https://runb
 
 A CircleCI pipeline compiles the source files from this directory to html, and updates the [target repository].
 
+## Publisher docker image
+
+A github action builds and pushes the [publisher docker image] to docker hub,
+whenever a new [release] is created via the github user interface.
+
 [target repository]: https://github.com/ministryofjustice/cloud-platform-runbooks
+[publisher docker image]: https://hub.docker.com/repository/docker/ministryofjustice/cloud-platform-runbooks
+[release]: https://github.com/ministryofjustice/cloud-platform/releases

--- a/runbooks/makefile
+++ b/runbooks/makefile
@@ -1,15 +1,6 @@
 IMAGE := ministryofjustice/cloud-platform-runbooks
-VERSION := 1.7 # Change this in .circleci/config.yml if you update it here
 
-.built-docker-image: Dockerfile Gemfile Gemfile.lock
-	docker build -t $(IMAGE) .
-	touch .built-docker-image
-
-docker-push: .built-docker-image
-	docker tag $(IMAGE) $(IMAGE):$(VERSION)
-	docker push $(IMAGE):$(VERSION)
-
-server: .built-docker-image
+server:
 	mkdir compiled || true
 	docker run \
 		-p 4567:4567 \
@@ -17,13 +8,13 @@ server: .built-docker-image
 		-v $$(pwd)/compiled:/app/compiled \
 		-v $$(pwd)/config:/app/config \
 		-it \
-		$(IMAGE):$(VERSION) bundle exec middleman server
+		$(IMAGE) bundle exec middleman server
 
 # The CircleCI build pipeline does this, so it should never
 # be necessary to run this task. I'm leaving it here for
 # reference, and in case we ever need to push changes
 # manually.
-build: .built-docker-image
+build:
 	mkdir compiled || true
 	docker run \
 		-v $$(pwd)/source:/app/source \


### PR DESCRIPTION
This replaces the previous process of changing the
tag in `runbooks/makefile` and running 
`make docker-push`