### PR TITLE
Change the CircleCI pipeline to work from "main"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     branches:
       only:
-        - master
+        - main
     docker:
       # This docker image is created from the Dockerfile in
       # this repository.


### PR DESCRIPTION
I thought I'd already made this change, but it must have gotten lost in
branch shuffling.