### PR TITLE
Correct the "GitHub" link on runbooks site

### DIFF
--- a/runbooks/config/tech-docs.yml
+++ b/runbooks/config/tech-docs.yml
@@ -12,7 +12,7 @@ header_links:
   'Feedback / Report a problem': 'mailto:platforms+runbooks@digital.justice.gov.uk?subject=Runbooks+feedback'
 
   Documentation: /
-  GitHub: https://github.com/ministryofjustice/cloud-platform/tree/master/runbooks
+  GitHub: https://github.com/ministryofjustice/cloud-platform/tree/main/runbooks
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.
 enable_search: true


### PR DESCRIPTION
The link should point to the "main" branch now.