### PR TITLE
Update links to point to "main" branch

### DIFF
--- a/runbooks/source/access-eks-cluster.html.md.erb
+++ b/runbooks/source/access-eks-cluster.html.md.erb
@@ -10,7 +10,7 @@ review_in: 3 months
 
 In order for kubectl to find and access a EKS cluster, it needs a kubeconfig file. When you create a new EKS cluster, the kubeconfig file is created locally within the [cloud-platform-eks/files/][files-folder] named as `files/kubeconfig_${WorkspaceName}` and only available for the user who created the cluster, other users who is authorized to access the cluster can create the kubeconfig file following the below process.
 
-## Pre-requisites 
+## Pre-requisites
 
 - Make sure you've access to Cloud Platform AWS account
 - Set your environment variables
@@ -55,7 +55,7 @@ You should now be able to run kubectl commands, try running such as `kubectl get
 
 ### Create kubeconfig manually using template
 
-Kubeconfig file can be created manually, using the below template. Login to AWS console, in the EKS service select the cluster you need to access. You will see all the information related to the EKS cluster, update `API server endpoint`, `Certificate authority` and `Cluster name` in the below kubeconfig template. 
+Kubeconfig file can be created manually, using the below template. Login to AWS console, in the EKS service select the cluster you need to access. You will see all the information related to the EKS cluster, update `API server endpoint`, `Certificate authority` and `Cluster name` in the below kubeconfig template.
 
 
 ```
@@ -92,5 +92,5 @@ users:
 Save the kubeconfig with a filename (eg.: ~/.kube/config_eks) and use the saved kubeconfig file to access the EKS cluster.
 
 
-[files-folder]: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cloud-platform-eks/files
+[files-folder]: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/cloud-platform-eks/files
 

--- a/runbooks/source/add-a-new-runbook.html.md.erb
+++ b/runbooks/source/add-a-new-runbook.html.md.erb
@@ -48,5 +48,4 @@ You can also use this to use the title as the heading
 
 CircleCI will compile and deploy a new version of the runbooks guide, with your changes.
 
-[source]: https://github.com/digitalronin/cloud-platform/tree/main/runbooks/source
 [cloud-platform]: https://github.com/ministryofjustice/cloud-platform

--- a/runbooks/source/add-a-new-runbook.html.md.erb
+++ b/runbooks/source/add-a-new-runbook.html.md.erb
@@ -48,5 +48,5 @@ You can also use this to use the title as the heading
 
 CircleCI will compile and deploy a new version of the runbooks guide, with your changes.
 
-[source]: https://github.com/digitalronin/cloud-platform/tree/master/runbooks/source
+[source]: https://github.com/digitalronin/cloud-platform/tree/main/runbooks/source
 [cloud-platform]: https://github.com/ministryofjustice/cloud-platform

--- a/runbooks/source/add-new-opa-policy.html.md.erb
+++ b/runbooks/source/add-new-opa-policy.html.md.erb
@@ -59,7 +59,7 @@ Additionally, tests will be run against pull requests to the repository in a Cir
 - [Kubernetes Policy Primer
 ][policy-primer]
 
-[policies-repo]: https://github.com/ministryofjustice/cloud-platform-terraform-opa/tree/master/resources/policies
+[policies-repo]: https://github.com/ministryofjustice/cloud-platform-terraform-opa/tree/main/resources/policies
 [policy-primer]: https://github.com/timothyhinrichs/opa/blob/4d5a1071e5099da42c2cde02faac2075f3ba2bf9/docs/content/docs/policy-primer-k8s.md
 [write-policies]: https://www.openpolicyagent.org/docs/latest/how-do-i-write-policies/
 [write-tests]: https://www.openpolicyagent.org/docs/latest/how-do-i-test-policies/

--- a/runbooks/source/add-new-receiver-alert-manager.html.md.erb
+++ b/runbooks/source/add-new-receiver-alert-manager.html.md.erb
@@ -11,7 +11,7 @@ When Development Teams require to send custom alarms to their own channels the A
 
 ## Pre-requisites
 
-You must have the below details from the development team. 
+You must have the below details from the development team.
 
 * namespace name
 * team name
@@ -22,9 +22,9 @@ You must have the below details from the development team.
 
 ## Creating a new receiver set
 
-1. Fill in the template with the details provided from development team and add the array to [`terraform.tfvars`](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/terraform.tfvars) file.
-The `terraform.tfvars` file is encrypted so you have to `git-crypt unlock` to view the contents of the file. 
-Check [git-crypt documentation in user guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/git-crypt-setup.html#git-crypt) for more information on how to setup git-crypt. 
+1. Fill in the template with the details provided from development team and add the array to [`terraform.tfvars`](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/cloud-platform-components/terraform.tfvars) file.
+The `terraform.tfvars` file is encrypted so you have to `git-crypt unlock` to view the contents of the file.
+Check [git-crypt documentation in user guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/git-crypt-setup.html#git-crypt) for more information on how to setup git-crypt.
 
     ```
     {
@@ -79,7 +79,7 @@ spec:
 
 AlertManager receivers for slack integration are configured for 2 type of alerts.
 
-1. to send a warning upon a alert rule condition is met and a recovery message once the condition is reversed  
+1. to send a warning upon a alert rule condition is met and a recovery message once the condition is reversed
 2. to send a information type alert for monitoring non-problem/non-failure events and no recovery message - e.g for rule condition to positively know something happened (like a database refresh, or app deployment etc) which is not of type of problem/failure.
 
 All alerts are routed using the severity label set from the prometheus rule. If the severity label matches the keyword `info-`<severity> then it is routed to information type receivers.
@@ -118,5 +118,5 @@ spec:
       annotations:
         message: Latest backup checker Job completed on Namespace {{ $labels.namespace }}
 ```
- 
+
 Check the user guide for more details on [how to setup custom prometheus alerts](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts).

--- a/runbooks/source/add-nodes-to-the-eks-cluster.html.md.erb
+++ b/runbooks/source/add-nodes-to-the-eks-cluster.html.md.erb
@@ -17,16 +17,16 @@ This can address the problem of CPU high usage/load
 
 #### 1. Ensure you have access to the Cloud Platform AWS account
 
-#### 2. Access to the EKS cluster 
+#### 2. Access to the EKS cluster
 
 [Access to the EKS cluster](https://runbooks.cloud-platform.service.justice.gov.uk/access-eks-cluster.html#access-eks-cluster)
 
 ### Cluster configuration:
 
 
-#### [cluster.tf](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-eks/cluster.tf)
+#### [cluster.tf](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/cloud-platform-eks/cluster.tf)
 
-Use 
+Use
 
 `git crypt unlock` to see the following code:
 
@@ -50,7 +50,7 @@ Use
     }
 ```
 
-#### [Variable.tf](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-eks/variables.tf)
+#### [Variable.tf](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/cloud-platform-eks/variables.tf)
 
 ```
 variable "vpc_name" {
@@ -76,7 +76,7 @@ The issue is to do with auto-scaling complexities utilising Terrafom - please se
 
 Therefore you either have to update default "worker_node_machine_type" to - in above example "m4.xlarge" and also the default "cluster_node_count" to in above example "5" or "6"
 
-Or you have to edit the "Desired size" in the "AWS EKS dashboard Edit Node Group" (once you have carried out the AWS dashboard change - update the terraform config, `terraform apply`  accordingly - so that it is in sync with the AWS dashboard): 
+Or you have to edit the "Desired size" in the "AWS EKS dashboard Edit Node Group" (once you have carried out the AWS dashboard change - update the terraform config, `terraform apply`  accordingly - so that it is in sync with the AWS dashboard):
 
 #### [AWS dashboard EKS - Edit Node Group:](https://eu-west-2.console.aws.amazon.com/eks/home?region=eu-west-2#/clusters/manager/nodegroups/manager-default_ng-able-koala/edit-nodegroup)
 

--- a/runbooks/source/auth0-rotation.html.md.erb
+++ b/runbooks/source/auth0-rotation.html.md.erb
@@ -5,7 +5,7 @@ last_reviewed_on: 2020-06-25
 review_in: 3 months
 ---
 
-# <%= current_page.data.title %> 
+# <%= current_page.data.title %>
 
 Cloud-Platform team uses [auth0](https://auth0.com) with almost every component which requires authentication (clusters, Prometheus, Kibana, Grafana, etc). Credentials rotation within our live clusters requires to follow different steps and because of that users are not able to use the cluster until they re-authenticate (generate new kubeconfig file)
 
@@ -17,7 +17,7 @@ Cloud-Platform team uses [auth0](https://auth0.com) with almost every component 
 
 ## 1) Taint resources (terraform)
 
-The first step is to recreate auth0 app. We will have to taint the auth0 resource, so it gets recreated with new credentials. Go to [`cloud-platform-infrastructure/terraform/cloud-platform` directory](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cloud-platform) and run
+The first step is to recreate auth0 app. We will have to taint the auth0 resource, so it gets recreated with new credentials. Go to [`cloud-platform-infrastructure/terraform/cloud-platform` directory](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/cloud-platform) and run
 
 ```
 $ terraform workspace select live-1
@@ -32,13 +32,13 @@ $ terraform apply
 
 ## 2) Rolling update of cluster (kops)
 
-From the previous step a new [cloud-platform-infrastructure/kops/live-1.yaml](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/kops/live-1.yaml) file should have been generated. To apply this file we [already have a runbook](https://runbooks.cloud-platform.service.justice.gov.uk/running-kops-update-rollingupdate.html#updating-the-remote-kops-state), follow it step by step.
+From the previous step a new [cloud-platform-infrastructure/kops/live-1.yaml](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/kops/live-1.yaml) file should have been generated. To apply this file we [already have a runbook](https://runbooks.cloud-platform.service.justice.gov.uk/running-kops-update-rollingupdate.html#updating-the-remote-kops-state), follow it step by step.
 
 **NOTE**: As you will see, the change will require rolling replacement of the master nodes
 
 ## 3) Apply changes within components (terraform)
 
-Execute `terraform plan` inside [`cloud-platform-infrastructure/terraform/cloud-platform-components` directory](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cloud-platform-components) and to ensure changes match resources below, if they do, apply them:
+Execute `terraform plan` inside [`cloud-platform-infrastructure/terraform/cloud-platform-components` directory](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/cloud-platform-components) and to ensure changes match resources below, if they do, apply them:
 
 ```
 $ terraform apply -target=module.prometheus.kubernetes_secret.grafana_secret -target=module.prometheus.helm_release.prometheus_proxy -target=module.prometheus.helm_release.alertmanager_proxy  -target=helm_release.kuberos
@@ -53,7 +53,7 @@ $ kubectl -n monitoring delete pod $GrafanaPodName
 
 ## 4) Update environment repo
 
-We already have a [ticket](https://github.com/ministryofjustice/cloud-platform/issues/2006) to get rid of this step. Meanwhile we get it done, we should update [`oidc-components-secret.yaml` file](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/oidc-components-secret.yaml) with the new auth0 credentials.
+We already have a [ticket](https://github.com/ministryofjustice/cloud-platform/issues/2006) to get rid of this step. Meanwhile we get it done, we should update [`oidc-components-secret.yaml` file](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/oidc-components-secret.yaml) with the new auth0 credentials.
 
 This step requires a PR and someone available to approve it.
 
@@ -61,7 +61,7 @@ This step requires a PR and someone available to approve it.
 
 In order to verify that the changes were successfully applied, follow the checklist below (order doesn't matter):
 
-- You can authenticate to the cluster (follow [user guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/kubectl-config.html#authentication)) 
+- You can authenticate to the cluster (follow [user guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/kubectl-config.html#authentication))
 - Ensure you can authenticate to [Grafana](https://grafana.cloud-platform.service.justice.gov.uk/)
 - Ensure you can authenticate to [AlertManager](https://alertmanager.cloud-platform.service.justice.gov.uk/)
 - Ensure you can authenticate to [Kibana](https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/home?_g=())
@@ -71,6 +71,6 @@ If all of this works, jump to the last step which is update our pipelines.
 
 ## 6) Update pipelines
 
-Our pipelines read auth0 credentials from a K8S secret inside the manager cluster. This secret is updated through concourse's TF module variable called `tf_provider_auth0_client_secret` and `tf_provider_auth0_client_id` in [cloud-platform-infrastructure/blob/master/terraform/cloud-platform-eks/components/terraform.tfvars](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-eks/components/terraform.tfvars)
+Our pipelines read auth0 credentials from a K8S secret inside the manager cluster. This secret is updated through concourse's TF module variable called `tf_provider_auth0_client_secret` and `tf_provider_auth0_client_id` in [cloud-platform-infrastructure/blob/main/terraform/cloud-platform-eks/components/terraform.tfvars](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/cloud-platform-eks/components/terraform.tfvars)
 
 You only need to update the source code file and have your changed merged to master. The [bootstrap pipeline] will apply your change.

--- a/runbooks/source/aws-create-user.html.md.erb
+++ b/runbooks/source/aws-create-user.html.md.erb
@@ -7,9 +7,9 @@ review_in: 3 months
 
 # AWS Console Access
 
-New joiners for Cloud platform team will need AWS Console access for most things. IAM resources (users, groups, roles, etc) are managed by terraform so new users are nothing more than new resources **in terraform**. 
+New joiners for Cloud platform team will need AWS Console access for most things. IAM resources (users, groups, roles, etc) are managed by terraform so new users are nothing more than new resources **in terraform**.
 
-Related repositories: 
+Related repositories:
 
  - [cloud-platform-infrastructure/terraform/global-resources/iam][iam-main-tf]
 
@@ -23,10 +23,10 @@ Related repositories:
 
 3) Create the PR and ask the team to review it.
 
-4) Once PR gets merged you must proceed to execute `terraform apply` and verify user (you can use AWS Console for this). 
+4) Once PR gets merged you must proceed to execute `terraform apply` and verify user (you can use AWS Console for this).
 
 ## Activating MFA for new users
 
 Unfortunataly terraform can't activate MFA for users, this process must be done done manually either [thorugh AWS Console (UI)](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_virtual.html) or [through the AWS CLI](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_cliapi.html).
 
-[iam-main-tf](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/global-resources/iam/main.tf)
+[iam-main-tf](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/global-resources/iam/main.tf)

--- a/runbooks/source/aws-guardduty.html.md.erb
+++ b/runbooks/source/aws-guardduty.html.md.erb
@@ -81,7 +81,7 @@ Please also see [terraform AWS GuardDuty detector ](https://www.terraform.io/doc
 
 #### Main Configuration File
 
-['guardduty.tf'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/global-resources/guardduty.tf) contains code for the following config:
+['guardduty.tf'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/global-resources/guardduty.tf) contains code for the following config:
 
 * Enabling and turning GuardDuty on for the master account.
 * Enabling and turning GuardDuty on for the member account.
@@ -94,7 +94,7 @@ Please also see [terraform AWS GuardDuty detector ](https://www.terraform.io/doc
 
 #### Terraform Variables File
 
-['terraform.tfvars'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/global-resources/terraform.tfvars) contains code for the following config variables:
+['terraform.tfvars'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/global-resources/terraform.tfvars) contains code for the following config variables:
 
 * aws_region
 * aws_profile for the master and member accounts (set locally in ~/.aws/credentials). This is set up using format "moj-[account] (see terraform.tfvars file)
@@ -106,7 +106,7 @@ Please also see [terraform AWS GuardDuty detector ](https://www.terraform.io/doc
 * member_email (the email to which the initial invitation email(s) should be sent {from the master account} when setting up GuardDuty on the member account - this must match email used to set up the root account)
 #### AWS Cloudwatch Event Rules File
 
-['event-pattern.json'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/global-resources/resources/event-pattern.json)
+['event-pattern.json'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/global-resources/resources/event-pattern.json)
 
 * A json object that is used by 'AWS Cloudwatch Event Rules' and related 'Targets' to select 'AWS Guardduty Events' (findings) and route them to the AWS sns targets.
 
@@ -160,14 +160,14 @@ Example (high priority):
 
 #### Trusted ip List File
 
-['iplist.txt'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/global-resources/resources/iplist.txt)
+['iplist.txt'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/global-resources/resources/iplist.txt)
 
 * A trusted ip list. GuardDuty does not generate findings for IP addresses that are included in this trusted IP list/s
 At this point in time terraform is unable to update this list by 'terraform apply'. The list has to be manually deleted in the AWS dashboard >  Guardduty > Lists > Trusted IP Lists. Then you can run the 'terraform apply.
 
 #### Variables Initialisation File
 
-['variables.tf'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/global-resources/variables.tf)
+['variables.tf'](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/global-resources/variables.tf)
 
 * Used to set up the terraform variables and defaults required by terraform 'guardduty.tf'
 
@@ -253,5 +253,5 @@ If the above is not possible - due to the AWS account having already been delete
 
 This is is also set up utilising terraform separately config here:
 
-* https://github.com/ministryofjustice/cloudplatforms-terraform-ops/blob/master/main.tf
-* https://github.com/ministryofjustice/cloudplatforms-terraform-ops/blob/master/services/amazon-guardduty-notifications/pagerduty.tf
+* https://github.com/ministryofjustice/cloudplatforms-terraform-ops/blob/main/main.tf
+* https://github.com/ministryofjustice/cloudplatforms-terraform-ops/blob/main/services/amazon-guardduty-notifications/pagerduty.tf

--- a/runbooks/source/create-cluster.html.md.erb
+++ b/runbooks/source/create-cluster.html.md.erb
@@ -53,10 +53,10 @@ By default, the script will create a 'small' cluster. This means the master and 
 
 See the script source code for the precise machine types used for the different sizes. The machine types used for 'production' clusters should always be the same machine types as we use in production.
 
-See more options to use when creating the cluster by running 
+See more options to use when creating the cluster by running
 
 ```bash
-./create-cluster.rb --help 
+./create-cluster.rb --help
 ```
 
 The script takes around 30 minutes to execute. At the end, you should see output like this:
@@ -156,7 +156,7 @@ https://login.apps.david-test1.cloud-platform.service.justice.gov.uk
 ```
 
 [infrastructure repo]: https://github.com/ministryofjustice/cloud-platform-infrastructure
-[cluster naming policy]: https://github.com/ministryofjustice/cloud-platform/blob/master/architecture-decision-record/009-Naming-convention-for-clusters.md
+[cluster naming policy]: https://github.com/ministryofjustice/cloud-platform/blob/main/architecture-decision-record/009-Naming-convention-for-clusters.md
 [AWS CLI]: https://aws.amazon.com/cli/
 [docker]: https://www.docker.com/
 [PagerDuty]: https://www.pagerduty.com/

--- a/runbooks/source/delete-cluster.html.md.erb
+++ b/runbooks/source/delete-cluster.html.md.erb
@@ -105,4 +105,4 @@ $ terraform workspace delete <clusterName>
 ```
 
 [infrastructure repo]: https://github.com/ministryofjustice/cloud-platform-infrastructure
-[destroy-cluster.rb]: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/destroy-cluster.rb
+[destroy-cluster.rb]: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/destroy-cluster.rb

--- a/runbooks/source/disaster-recovery-scenarios.html.md.erb
+++ b/runbooks/source/disaster-recovery-scenarios.html.md.erb
@@ -11,11 +11,11 @@ This section will document various scenarios that will create an incident. Each 
 
 ## Losing a Namespace
 
-### Impact 
+### Impact
 A loss of a namespace will result in losing all resources within the namespace including ingress.
 
 ### Possible Cause
-User error - Executing `kubectl delete ns my-namespace-dev` 
+User error - Executing `kubectl delete ns my-namespace-dev`
 
 ```
 kubectl get all -n my-namespace-dev
@@ -66,11 +66,11 @@ replicaset.apps/replicaset1          1         1         1       1m
 
 ## Losing a Kubernetes Component or Object
 
-### Impact 
+### Impact
 A loss of a kubernetes object such as a deployment, secret and Namespace can result in an application not working correctly. A loss of a Kubernetes component such as kube-scheduler or kube-control-manager can result in the cluster not working correctly.
 
 ### Possible Cause
-User error - Executing `kubectl delete deployment/my-deployment-name ns my-namespace-dev` 
+User error - Executing `kubectl delete deployment/my-deployment-name ns my-namespace-dev`
 
 ```
 kubectl get deployment/my-deployment-name -n my-namespace-dev
@@ -113,18 +113,18 @@ deployment.apps/my-deployment-name        1/1       1            1         1m
 
 ## Losing the whole cluster
 
-### Impact 
+### Impact
 
 Severity : HIGH
 
 Likelihood: LOW
 
-Losing the whole kubernetes cluster will result in all services not being available. This means all the 
+Losing the whole kubernetes cluster will result in all services not being available. This means all the
 resources within all namespaces, networking, monitoring and logging systems.
 
 ### Possible Cause
 
-Losing the whole cluster is less likely and the possible causes may vary. 
+Losing the whole cluster is less likely and the possible causes may vary.
 
 User error - Deleting all EC2 instances of `<cluster-name>` from console by accident
 
@@ -134,10 +134,10 @@ The first sign of this happening is likely to be Pagerduty alarms to the high/lo
 
 This way of restoring the whole cluster have been tested with below procedure
 
-1. Create cluster using the [script](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/create-cluster.rb)
-2. Deploy [starter pack](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/starter-pack.tf) to replicate user namespaces
+1. Create cluster using the [script](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/create-cluster.rb)
+2. Deploy [starter pack](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/cloud-platform-components/starter-pack.tf) to replicate user namespaces
 3. Take backup of the whole cluster using [velero](velero.html#velero-cluster-backups-and-disaster-recovery)
-4. Destroy the cluster excluding the VPC using the [script](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/destroy-cluster.rb)
+4. Destroy the cluster excluding the VPC using the [script](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/destroy-cluster.rb)
 5. Create a cluster with the same name. That way velero can match the backup storage location
 6. Restore the cluster from the backup taken in Step 3
 
@@ -151,8 +151,8 @@ This way of restoring the whole cluster have been tested with below procedure
 ### Restore process
 Any namespaces over 3 hours old can be recovered using Velero (newer namespaces might not have been backed up before the incident occurred).
 
-Create the cluster with the **same** name from the [source code](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/create-cluster.rb)
-and provide the exisiting `vpc-name`. This will link the velero backup locations to the lost cluster. 
+Create the cluster with the **same** name from the [source code](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/create-cluster.rb)
+and provide the exisiting `vpc-name`. This will link the velero backup locations to the lost cluster.
 
 Find the name of the most recent backup of the `allnamespacebackup` schedule:
 
@@ -176,7 +176,7 @@ Example:
 velero restore create my-namespace-dev-restore --from-backup velero-allnamespacebackup-00000000000000 --wait
 ```
 
-Once completed, you should be able to see resources in all namespaces recovered. 
+Once completed, you should be able to see resources in all namespaces recovered.
 
 Check the status of the restore and look for errors and warnings:
 
@@ -193,20 +193,20 @@ velero restore logs velero-allnamespacebackup-00000000000000-00000000000000
 
 ## Deleted/corrupted the kops state
 
-### Impact 
+### Impact
 
 Severity : LOW
 
 Likelihood: LOW/MEDIUM
 
-When the kops state is corrupted, in most cases the kubernetes cluster will still be operational. 
+When the kops state is corrupted, in most cases the kubernetes cluster will still be operational.
 
-This means the services will not have any impact, if the issue is resolved in a shorter amount of time. 
+This means the services will not have any impact, if the issue is resolved in a shorter amount of time.
 
-Leaving the cluster in the corrupted kops state for a prolonged period will reduce the cluster being highly available 
+Leaving the cluster in the corrupted kops state for a prolonged period will reduce the cluster being highly available
 and not handle any failover in case one or more masters has gone down.
 
-Hence, Cloud platform team will not be able to perform any infrastructure changes. Also, teams will not able to communicate with the cluster 
+Hence, Cloud platform team will not be able to perform any infrastructure changes. Also, teams will not able to communicate with the cluster
 to deploy applications or schedule any jobs.
 
 ### Possible Cause
@@ -221,9 +221,9 @@ It could also be corrupted/lost if a user deleted the s3 bucket by accident wher
 
 The sign of this happening can be seen when doing `kops validate cluster <cluster name>`
 
-If the kops state is corrupted, some of the worker nodes or masters machines will not join the cluster. 
+If the kops state is corrupted, some of the worker nodes or masters machines will not join the cluster.
 
-The above command will show something similar to 
+The above command will show something similar to
 
 ```
 
@@ -245,9 +245,9 @@ error reading cluster configuration: Cluster.kops.k8s.io "<cluster name>.cloud-p
 
 ### Restore process for corrupted kops state
 
-The cluster kops state is stored in the generated yaml file inside the folder kops/`<CLUSTER_NAME>`.yaml. 
+The cluster kops state is stored in the generated yaml file inside the folder kops/`<CLUSTER_NAME>`.yaml.
 
-For `live-1` the generated kops yaml file is stored in the [github](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/kops/live-1.yaml).
+For `live-1` the generated kops yaml file is stored in the [github](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/kops/live-1.yaml).
 So, checkout the previous working commit and update the remote kops state with that file.
 
 If the cluster state is corrupted due to the latest changes to the yaml file, revert back the changes and update the remote kops state.
@@ -279,20 +279,20 @@ kops update cluster --yes
 kops rolling-update cluster --yes
 ```
 
-For more information on kops update, rolling-update and debugging instructions, refer 
+For more information on kops update, rolling-update and debugging instructions, refer
 [runbook for kops update](running-kops-update-rollingupdate.html#running-kops-update-and-rollingupdate)
 
-If the restore process require creating new instancegroup for worker nodes, follow the procedure mentioned 
+If the restore process require creating new instancegroup for worker nodes, follow the procedure mentioned
 in [Upgrade a cluster](https://runbooks.cloud-platform.service.justice.gov.uk/upgrade-cluster.html#upgrade-a-cluster).
 
-The difference to the upgrading procedure would be 
+The difference to the upgrading procedure would be
 
 - reverting the kops yaml file to old working version of kubernetes and
 
 - if new instancegroup for worker nodes is needed, then to create one with working kubernetes version and move workload back to that worker nodes.
 
 ### Restore process for deleted S3 bucket where kops state is stored
-Kops state of all clusters are backed up in a different s3 bucket `kops-backup-replication` in the region `eu-west-2`. 
+Kops state of all clusters are backed up in a different s3 bucket `kops-backup-replication` in the region `eu-west-2`.
 
 If the entire folder where the cluster state is stored is lost/corrupted, copy the folder from the backup bucket by running below
 
@@ -305,7 +305,7 @@ Validate the cluster
 ```
 kops validate cluster <cluster name>
 ```
-The validation should be success and should say 
+The validation should be success and should say
 
 **"Your cluster `<cluster name>`.cloud-platform.service.justice.gov.uk is ready"**
 
@@ -316,8 +316,8 @@ Severity : low
 
 Likelihood: medium
 
-### Impact 
-Items removed from the terraform state are not physically destroyed but no longer managed by terraform. This means infrastructure is orphaned with no state. 
+### Impact
+Items removed from the terraform state are not physically destroyed but no longer managed by terraform. This means infrastructure is orphaned with no state.
 
 For example, if you remove an AWS instance from the state, the AWS instance will continue running, but terraform plan will no longer see that instance.
 
@@ -339,7 +339,7 @@ terraform import module.starter_pack.kubernetes_namespace.starter_pack starter-p
 
 ```
 
-The import command creates a new state file pulling in information about the specified kubernetes_namespace. 
+The import command creates a new state file pulling in information about the specified kubernetes_namespace.
 
 ```
 module.starter_pack.kubernetes_namespace.starter_pack: Importing from ID "starter-pack"...
@@ -372,7 +372,7 @@ Plan: 7 to add, 0 to change, 0 to destroy.
 
 In this scenario, terraform state can be restored from the remote_state stored in the terraform backend S3 bucket.
 
-For example [cloud-platform-components](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cloud-platform-components) state is stored in "cloud-platform-terraform-state/cloud-platform-components" s3 bucket as defined [here](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/main.tf#L1-L9).
+For example [cloud-platform-components](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/cloud-platform-components) state is stored in "cloud-platform-terraform-state/cloud-platform-components" s3 bucket as defined [here](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/cloud-platform-components/main.tf#L1-L9).
 
 Access the S3 bucket where the effected terraform state is stored. From the list of terraform.tfstate file versions, identify the file before the state got removed and download as terraform.tfstate. Upload the file again, this will set uploaded file as latest version.
 

--- a/runbooks/source/disaster-recovery.html.md.erb
+++ b/runbooks/source/disaster-recovery.html.md.erb
@@ -9,7 +9,7 @@ review_in: 3 months
 
 Cloud Platform Kubernetes cluster deployed with kops use [etcd-manager][etcd-manager-rep] to do backups periodically and before cluster modifications. Backups for both the main and events etcd clusters are stored in 's3://cloud-platform-kops-state/${CLUSTER_NAME}.cloud-platform.service.justice.gov.uk' together with the cluster configuration.
 
-In case of a disaster situation (total failure, Kops delete cluster, lost data, cluster issues etc.) it's possible to do a restore from the backup using [etcd-manager][etcd-manager-rep]. More details about the usage can be found [here][etcd-manager-restore] and [here][kops-backup-restore]. 
+In case of a disaster situation (total failure, Kops delete cluster, lost data, cluster issues etc.) it's possible to do a restore from the backup using [etcd-manager][etcd-manager-rep]. More details about the usage can be found [here][etcd-manager-restore] and [here][kops-backup-restore].
 
 ## Restore process
 
@@ -114,9 +114,9 @@ To restore the deleted backups, follow the below steps:
 
 Sign in to the AWS Management Console and open the Amazon S3 console and access 'cloud-platform-kops-state/${CLUSTER_NAME}.cloud-platform.service.justice.gov.uk/backups/etcd.
 
-Select main and click on `show` option in `versions`, you can view deleted backups now. 
+Select main and click on `show` option in `versions`, you can view deleted backups now.
 
-Click on the deleted backup you want to restore from, you will see `etcd_backup.meta` and `etcd.backup.gz` files set as (Delete marker). 
+Click on the deleted backup you want to restore from, you will see `etcd_backup.meta` and `etcd.backup.gz` files set as (Delete marker).
 
 Delete those (Delete marker) files by using delete option in actions (you can see in the below image), removing the delete marker files will get the backup files into active stage. Do the same for events.
 
@@ -155,7 +155,7 @@ I0829 10:57:53.294703   34271 vfs.go:94] listed backups in s3://cloud-platform-k
 
 Restore the latest backup in the list, or the one containing the timestamp you want to restore from (this will bring the entire cluster back to this point in time). Add a restore command for both main and events as below:
 
-Note: We can only use a backup file which is returned in the results of the list-backups command. If kops deleted the backups it will not show up in the list. Follow this [guidance][restore-deleted-backups] to get the deleted backups into active stage, which will then show up in the list-backups. 
+Note: We can only use a backup file which is returned in the results of the list-backups command. If kops deleted the backups it will not show up in the list. Follow this [guidance][restore-deleted-backups] to get the deleted backups into active stage, which will then show up in the list-backups.
 
 ```
 etcd-manager-ctl -backup-store=s3://cloud-platform-kops-state/${CLUSTER_NAME}.cloud-platform.service.justice.gov.uk/backups/etcd/main restore-backup 2019-08-27T16:44:23Z-001038
@@ -179,7 +179,7 @@ The etcd-manager containers should restart automatically, and pick up the restor
 
 To reboot all masters, follow below process.
 
-In the Amazon EC2 console, on the Instances page, search using `${CLUSTER_NAME}` to locate cluster master and worker instances(`master-<availability-zone>.masters.<cluster_name>.cloud-platform.service.justice.gov.uk`). 
+In the Amazon EC2 console, on the Instances page, search using `${CLUSTER_NAME}` to locate cluster master and worker instances(`master-<availability-zone>.masters.<cluster_name>.cloud-platform.service.justice.gov.uk`).
 
 Select all master instances together, and run reboot from actions>instancestate>reboot.
 Run the below command to validate the cluster.
@@ -188,7 +188,7 @@ Run the below command to validate the cluster.
 kops validate cluster ${CLUSTER_NAME}.cloud-platform.service.justice.gov.uk
 ```
 
-All master and worker node should join the cluster, you can see the cluster is in ready status. 
+All master and worker node should join the cluster, you can see the cluster is in ready status.
 
 ```
 Your cluster ${CLUSTER_NAME}.cloud-platform.service.justice.gov.uk is ready
@@ -251,7 +251,7 @@ If you don't have etcd-manager-ctl installed on your workstation, you can run th
 
 Note: If you already performed restore process via etcd-manager-ctl on your [computer][etcd-managet-ctl-terminal], don't repeat this in etcd container.
 
-Run the below command on all the etcd-manager-main and etcd-manager-event containers, to find out the leader of the cluster for main and events. 
+Run the below command on all the etcd-manager-main and etcd-manager-event containers, to find out the leader of the cluster for main and events.
 
 ```
 kubectl -n kube-system logs etcd-manager-main-ip-172-xx-xx-226.eu-west-2.compute.internal | grep leader
@@ -269,7 +269,7 @@ etcd-manager-main-ip-172-xx-xx-223.eu-west-2.compute.internal etcd-manager I0830
 etcd-manager-main-ip-172-xx-xx-57.eu-west-2.compute.internal etcd-manager I0830  ..... we are not leader
 ```
 
-From the above output, ssh in to leader master node via bastion instance: 
+From the above output, ssh in to leader master node via bastion instance:
 
 In the Amazon EC2 console, on the Instances page, search using `${CLUSTER_NAME}`to locate bastion instance (`bastion.<cluster_name>.cloud-platform.service.justice.gov.uk`). Use Public DNS (IPv4) In the description of the Instance to login in to bastion as below:
 
@@ -280,7 +280,7 @@ ssh -A admin@ec2-35-176-xx-xx.eu-west-2.compute.amazonaws.com -p 50422
 
 From the bastion, login to the leader master node:
 
-In the Amazon EC2 console, on the Instances page, search using `${CLUSTER_NAME}` to locate master instance (`master-<availability-zone>.masters.<cluster_name>.cloud-platform.service.justice.gov.uk`). From the result above to identify the leader, use the ip address of the leader master node and ssh in to it. 
+In the Amazon EC2 console, on the Instances page, search using `${CLUSTER_NAME}` to locate master instance (`master-<availability-zone>.masters.<cluster_name>.cloud-platform.service.justice.gov.uk`). From the result above to identify the leader, use the ip address of the leader master node and ssh in to it.
 
 ```bash
 ssh 172.20.xx.xx
@@ -370,7 +370,7 @@ subsets:
     protocol: TCP
 
 ```
-or 
+or
 
 You can get the old master IPs by describing the kubernetes service (under Endpoints):
 
@@ -509,7 +509,7 @@ subsets:
 
 1) If any Master node stuck in `not ready` status, [reboot][master-reboot] that master again, from the aws console or [restart][container-restart] etcd for that master node.
 
-2) Master nodes are in ready status but worker nodes has not yet joined cluster 
+2) Master nodes are in ready status but worker nodes has not yet joined cluster
 
 ```
 NODE STATUS
@@ -627,7 +627,7 @@ This issue is due to old master IPs being set as endpoints in the kubernetes ser
 
 [etcd-manager-rep]: https://github.com/kopeio/etcd-manager
 [cpi-repo]: https://github.com/ministryofjustice/cloud-platform-infrastructure
-[kops-repo]: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/kops
+[kops-repo]: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/kops
 [etcd-managet-ctl]: https://github.com/kopeio/etcd-manager/releases/
 [etcd-manager-restore]: https://github.com/kopeio/etcd-manager/blob/master/docs/backup-restore.md
 [kops-backup-restore]: https://github.com/kubernetes/kops/blob/master/docs/operations/etcd_backup_restore_encryption.md
@@ -641,4 +641,4 @@ This issue is due to old master IPs being set as endpoints in the kubernetes ser
 [master-reboot]: disaster-recovery.html#roll-masters-by-rebooting
 [container-restart]: disaster-recovery.html#restart-etcd
 [cleanup]: disaster-recovery.html#cleanup
-[tf-cloud-platform]: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cloud-platform
+[tf-cloud-platform]: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/cloud-platform

--- a/runbooks/source/eks-tools-cluster.html.md.erb
+++ b/runbooks/source/eks-tools-cluster.html.md.erb
@@ -7,7 +7,7 @@ review_in: 3 months
 
 # Provisioning EKS clusters
 
-For the time being EKS is only used for the manager cluster, it mainly holds Cloud Platform concourse CI. 
+For the time being EKS is only used for the manager cluster, it mainly holds Cloud Platform concourse CI.
 
 **IMPORTANT:** All cluster's names **must be globally unique** (EKS or kOps). Each one creates a unique Route53 hostzone which is unique to the name
 
@@ -25,7 +25,7 @@ For the time being EKS is only used for the manager cluster, it mainly holds Clo
 
 ### 1. VPC
 
-We need to create a VPC to deploy the cluster, VPCs are deployed using terraform code under [cloud-platform-infrastructure/terraform/cloud-platform-network](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cloud-platform-network) folder:
+We need to create a VPC to deploy the cluster, VPCs are deployed using terraform code under [cloud-platform-infrastructure/terraform/cloud-platform-network](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/cloud-platform-network) folder:
 
 ```
 cd cloud-platform-infrastructure/terraform/cloud-platform-network
@@ -40,15 +40,15 @@ You should be able to see your new VPC (called `WorkspaceName`) inside the AWS C
 
 ### 2. Creating EKS cluster
 
-Now it's time to provision the cluster itself, we change directory to [cloud-platform-infrastructure/terraform/cloud-platform-eks](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cloud-platform-eks) and follow very similar terraform workflow:
+Now it's time to provision the cluster itself, we change directory to [cloud-platform-infrastructure/terraform/cloud-platform-eks](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/cloud-platform-eks) and follow very similar terraform workflow:
 
 ```
 terraform init
-terraform workspace new <WorkspaceName> 
+terraform workspace new <WorkspaceName>
 terraform apply -var="vpc_name=$VPC_NAME"
 ```
 
-`vpc_name` must be set, it's the only required variable. It can also be used variables like `cluster_node_count` and `worker_node_machine_type` to set up different node groups parameters 
+`vpc_name` must be set, it's the only required variable. It can also be used variables like `cluster_node_count` and `worker_node_machine_type` to set up different node groups parameters
 
 Once terraform finishes you should be able to generate your kubeadmin file (used by _kubectl_ to establish a connection to the cluster) using aws-cli in the following way:
 
@@ -71,7 +71,7 @@ To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
 
 ### 3. Deploy components
 
-Components installation is the last step, for that we need to have the `KUBECONFIG` variable exported and make sure you have access to the cluster. To deploy components we go to [cloud-platform-infrastructure/terraform/cloud-platform-eks/components](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cloud-platform-eks/components) and follow exactly the same terraform workflow:
+Components installation is the last step, for that we need to have the `KUBECONFIG` variable exported and make sure you have access to the cluster. To deploy components we go to [cloud-platform-infrastructure/terraform/cloud-platform-eks/components](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/cloud-platform-eks/components) and follow exactly the same terraform workflow:
 
 ```
 terraform init
@@ -121,4 +121,4 @@ $ terraform workspace delete <clusterName>
 
 ## TODO
 
-- It would be nice to have similar script to [`create-cluster.rb`](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/create-cluster.rb) (or add to it support for EKS) that creates the whole process in one command.
+- It would be nice to have similar script to [`create-cluster.rb`](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/create-cluster.rb) (or add to it support for EKS) that creates the whole process in one command.

--- a/runbooks/source/how-we-work.html.md.erb
+++ b/runbooks/source/how-we-work.html.md.erb
@@ -61,7 +61,7 @@ It **is** the hammer's job to ensure that all queries are handled. This may invo
 
 Most of our user-facing documentation is in the [user guide], and documentation for the team is in the [runbooks] site.
 
-There are also a lot of important `README.md` files like [this one](https://github.com/ministryofjustice/cloud-platform#ministry-of-justice-cloud-platform-master-repo), especially for our terraform modules. We also have code samples like [this](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/blob/master/example/rds.tf) for each of our terraform modules.
+There are also a lot of important `README.md` files like [this one](https://github.com/ministryofjustice/cloud-platform#ministry-of-justice-cloud-platform-master-repo), especially for our terraform modules. We also have code samples like [this](https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/blob/main/example/rds.tf) for each of our terraform modules.
 
 It is important to keep all of this up to date as the underlying code changes, so please remember to factor this in when estimating and working on tickets.
 

--- a/runbooks/source/joiners-guide.html.md.erb
+++ b/runbooks/source/joiners-guide.html.md.erb
@@ -44,8 +44,8 @@ review_in: 3 months
     * [Runbooks](https://runbooks.cloud-platform.service.justice.gov.uk/#cloud-platform-runbooks)
     * [User guide](https://user-guide.cloud-platform.service.justice.gov.uk/#cloud-platform-user-guide)
     * [Main CP repo](https://github.com/ministryofjustice/cloud-platform)
-      * [Architecture diagram](https://github.com/ministryofjustice/cloud-platform/blob/master/docs/Architecture-Offical.md)
-      * [ADRs](https://github.com/ministryofjustice/cloud-platform/tree/master/architecture-decision-record#cloud-platform-architecture-decisions)
+      * [Architecture diagram](https://github.com/ministryofjustice/cloud-platform/blob/main/docs/Architecture-Offical.md)
+      * [ADRs](https://github.com/ministryofjustice/cloud-platform/tree/main/architecture-decision-record#cloud-platform-architecture-decisions)
     * [environments repo](https://github.com/ministryofjustice/cloud-platform-environments)
     * [Concourse](https://concourse.cloud-platform.service.justice.gov.uk/)
 

--- a/runbooks/source/manually-apply-namespace.html.md.erb
+++ b/runbooks/source/manually-apply-namespace.html.md.erb
@@ -13,7 +13,7 @@ These steps are more or less what the [concourse pipeline] does.
 
 ```
 cd cloud-platform-environments
-git checkout master
+git checkout main
 git pull
 git checkout -b [BRANCH-NAME] origin/[BRANCH-NAME]
 ```
@@ -60,4 +60,4 @@ terraform init \
 terraform plan
 ```
 
-[concourse pipeline]: https://github.com/ministryofjustice/cloud-platform-concourse/blob/master/pipelines/live-1/main/plan-environments.yaml
+[concourse pipeline]: https://github.com/ministryofjustice/cloud-platform-concourse/blob/main/pipelines/live-1/main/plan-environments.yaml

--- a/runbooks/source/manually-delete-namespace-resources.html.md.erb
+++ b/runbooks/source/manually-delete-namespace-resources.html.md.erb
@@ -37,5 +37,5 @@ To run the script:
 >
 > If this happens, just delete the whole `namespaces/live-1.cloud-platform.service.justice.gov.uk/[namespace name]` folder and re-run the script.
 
-[deleter script]: https://github.com/ministryofjustice/cloud-platform-environments/blob/master/bin/delete-namespace.rb
+[deleter script]: https://github.com/ministryofjustice/cloud-platform-environments/blob/main/bin/delete-namespace.rb
 [environments repository]: https://github.com/ministryofjustice/cloud-platform-environments

--- a/runbooks/source/public-s3-bucket.html.md.erb
+++ b/runbooks/source/public-s3-bucket.html.md.erb
@@ -15,5 +15,5 @@ The easiest way to do this is to [edit the environment variable] directly via th
 
 The function uses a substring test to see if the current bucket name appears in the `S3_EXCEPTION` string, so you can use any separator you want when you add the new bucket name to the variable.
 
-[lambda function]: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/cloudformation/aws-account-baseline-templates/aws-s3-enable-encryption-block-public-access
+[lambda function]: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/cloudformation/aws-account-baseline-templates/aws-s3-enable-encryption-block-public-access
 [edit the environment variable]: https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/S3BucketBlockPublicAccess?tab=configuration

--- a/runbooks/source/recycle-node.html.md.erb
+++ b/runbooks/source/recycle-node.html.md.erb
@@ -49,7 +49,7 @@ error: cannot delete Pods not managed by ReplicationController, ReplicaSet, Job,
 Then you can track down the namespace owner and ask them to clear up their pods by sending a message in the #ask-cloud-platform, something like:
 
 ```
-The recycle-node job failed because of some manually-created pods. 
+The recycle-node job failed because of some manually-created pods.
 
 If any of these pods are yours, and you're not using them anymore, please could you delete them so that the next time the recycle-node job runs, it is able to replace the node?
 
@@ -58,6 +58,6 @@ licences-dev/port-forward
 
 Once the pod causing the issue gets deleted, you can re-run the pipeline or just wait for the next scheduled run.
 
-[recycle-node-script]: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/recycle-node.rb
+[recycle-node-script]: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/recycle-node.rb
 [running-pipeline]: https://github.com/ministryofjustice/cloud-platform-concourse/blob/af90d767e674a38127af34021bce3bac2749bb61/pipelines/manager/main/maintenance.yaml#L53
-[recyclenode-pipeline-definition]: https://github.com/ministryofjustice/cloud-platform-concourse/blob/master/pipelines/live-1/main/recycle-node.yaml
+[recyclenode-pipeline-definition]: https://github.com/ministryofjustice/cloud-platform-concourse/blob/main/pipelines/live-1/main/recycle-node.yaml

--- a/runbooks/source/replacing-master-node.html.md.erb
+++ b/runbooks/source/replacing-master-node.html.md.erb
@@ -52,26 +52,26 @@ KIND    NAME            MESSAGE
 Machine i-046ed8d94d65719a6 machine "i-046ed8d94d65719a6" has not yet joined cluster
 ```
 
-This shows that one of the machines not joined the cluster. 
+This shows that one of the machines not joined the cluster.
 
-Make sure it is a master node by looking for the Instance ID in the Amazon EC2 console, on the Instances page. The instance ID should be something like: 
+Make sure it is a master node by looking for the Instance ID in the Amazon EC2 console, on the Instances page. The instance ID should be something like:
 
 ```
 master-<availability-zone>.masters.<cluster_name>.cloud-platform.service.justice.gov.uk
-``` 
- 
+```
+
 ##  Remove the unhealthy master node.
 
-As per [this guidance][remove-member-first] remove the unhealthy etcd member (i.e. the failed master node) first. 
- 
+As per [this guidance][remove-member-first] remove the unhealthy etcd member (i.e. the failed master node) first.
+
 Identify and remove the unhealthy member by accessing any of the working master nodes using SSH, via the bastion instance.
 
 In the Amazon EC2 console, on the Instances page, search using `${CLUSTER_NAME}`to locate the bastion instance:
- 
+
 ```
  bastion.<cluster_name>.cloud-platform.service.justice.gov.uk
  ```
- 
+
 Use the Public DNS (IPv4) in the description of the Instance to login in to bastion like this:
 
 
@@ -127,7 +127,7 @@ You will see list of members like this:
 27aaafc750f8d2f7, started, etcd-c, https://etcd-c.internal.test-etcd-1.cloud-platform.service.justice.gov.uk:2380, https://etcd-c.internal.test-etcd-1.cloud-platform.service.justice.gov.uk:4001
 8d4a23328d324c94, started, etcd-b, https://etcd-b.internal.test-etcd-1.cloud-platform.service.justice.gov.uk:2380, https://etcd-b.internal.test-etcd-1.cloud-platform.service.justice.gov.uk:4001
 ```
-The first value in each line is the ID of the member. We will need this to remove the member from the etcd cluster. 
+The first value in each line is the ID of the member. We will need this to remove the member from the etcd cluster.
 
 Identify the unhealthy member (the old master node) and run the command below to remove the member.
 
@@ -182,7 +182,7 @@ You will get a message like:
 Snapshot saved at /rootfs/mnt/snapshot.db
 ```
 
-The snapshot.db is saved at `/rootfs/mnt/`, which is volume mounted to a local directory at `/mnt`. 
+The snapshot.db is saved at `/rootfs/mnt/`, which is volume mounted to a local directory at `/mnt`.
 
 3) Edit the kops instance group for the master you removed, to scale down by replacing maxSize and minSize values to 0, and run a kops update on the cluster. e.g:
 
@@ -195,27 +195,27 @@ kops update cluster ${CLUSTER_NAME}.cloud-platform.service.justice.gov.uk --yes
 ```
 
 4) In the Amazon EC2 console, on the Instances page, search using `${CLUSTER_NAME}` to locate the failed master instance:
- 
+
 ```
  master-<availability-zone>.masters.<cluster_name>.cloud-platform.service.justice.gov.uk
  ```
- 
-Terminate the failed master instance following this [guide][terminate-ec2-instance]. 
+
+Terminate the failed master instance following this [guide][terminate-ec2-instance].
 
 #### etcd volumes
 
 Kubernetes live-1 cluster deployed with kops stores the etcd state in two different AWS EBS volumes per master node. One volume is used to store the Kubernetes main data, the other one for events. For a cluster with three masters this will result in six volumes for etcd data (one in each AZ).
- 
+
 5) In the Amazon EBS volume console, search using `${CLUSTER_NAME}` to locate the right volume associated with the broken master. Remove the volumes (main and events) for the failed master.
 
-For example, for the master node instance 
- 
+For example, for the master node instance
+
 ```
 master-eu-west-2a.masters.live-1.cloud-platform.service.justice.gov.uk
 ```
 
 ...you should see volumes called:
- 
+
 ```
 a.etcd-main.live-1.cloud-platform.service.justice.gov.uk
 a.etcd-events.live-1.cloud-platform.service.justice.gov.uk

--- a/runbooks/source/running-kops-update-rollingupdate.html.md.erb
+++ b/runbooks/source/running-kops-update-rollingupdate.html.md.erb
@@ -86,19 +86,19 @@ At this point, you should have an updated `kops/[cluster name].yaml` file in you
 Commit and push your changes, including those in the terraform source and template files.
 
 ### Applying local changes to the kops state store
-  
+
 #### Backup the remote kops state
-  
+
 If you want to preserve a backup of the current kops state on S3, you can do so like this:
-  
+
 ```bash
 aws s3 cp --recursive $KOPS_STATE_STORE/live-1.cloud-platform.service.justice.gov.uk $KOPS_STATE_STORE/live-1-backup
 ```
 
 This takes a couple of minutes. At time of writing, this was around 10G of data (mostly etcd backup tarballs).
-  
+
 > While the backup exists, `kops get clusters` will report "live-1" *twice*. This doesn't do any harm, but you do need to delete the backup in order to resolve this, either via the `aws` CLI too, or using the AWS web interface for S3.
-  
+
 #### Updating the remote kops state
 
 To apply your local changes to the kops state stored on S3:
@@ -193,4 +193,4 @@ While draining a node there is a chance that rolling update might be stuck at ev
 $ kubectl get pods -owide --all-namespaces | grep ${node_name}
 ```
 
-[kops dir]: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cloud-platform
+[kops dir]: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/cloud-platform

--- a/runbooks/source/tips-and-tricks.html.md.erb
+++ b/runbooks/source/tips-and-tricks.html.md.erb
@@ -116,7 +116,7 @@ sudo systemctl status docker
 
 ## Output all records from Route53 as a CSV file
 
-Use [this script](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/bin/route53-to-csv.rb)
+Use [this script](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/bin/route53-to-csv.rb)
 
 ## Add more RSS feeds to `#cloud-platform-rss` channel
 

--- a/runbooks/source/upgrade-cluster.html.md.erb
+++ b/runbooks/source/upgrade-cluster.html.md.erb
@@ -21,7 +21,7 @@ Setup the environment variables listed in `example.env.create-cluster` in the [i
 
 ### Run integration tests
 
-Run the [integration test pipeline] and wait for the tests to pass. This will ensure the live cluster is functioning as expected. 
+Run the [integration test pipeline] and wait for the tests to pass. This will ensure the live cluster is functioning as expected.
 
 ### Sanity checks
 
@@ -36,9 +36,9 @@ Take a snapshot of
 
 The cloud platform [tools image] has all the software required to run the build script and create a cluster.
 
-The image will need updates for new client tool versions, see https://github.com/ministryofjustice/cloud-platform-tools-image/pull/34 for an example. Make the required changes and push the new image to DockerHub. 
+The image will need updates for new client tool versions, see https://github.com/ministryofjustice/cloud-platform-tools-image/pull/34 for an example. Make the required changes and push the new image to DockerHub.
 
-From a local copy of the cloud-platform-infrastructure repository, run the following command (ensuring that you're using the new image): 
+From a local copy of the cloud-platform-infrastructure repository, run the following command (ensuring that you're using the new image):
 
 ```bash
 make tools-shell
@@ -59,7 +59,7 @@ kops export kubecfg XXXXXXX.cloud-platform.service.justice.gov.uk
 Open the cloud-platform-infrastructure repository and make the following changes to the kops/live-1.yaml manifest:
 
   - The Kubernetes release version, ensuring it is supported by Kops - verify on the [kops releases](https://github.com/kubernetes/kops/releases) page.
-  - The AMI in each instance group. This can be found here: https://github.com/kubernetes/kops/blob/master/channels/stable 
+  - The AMI in each instance group. This can be found here: https://github.com/kubernetes/kops/blob/master/channels/stable
 
 Now make the same changes to the template file `./terraform/cloud-platform/templates/kops.yaml.tpl`.
 
@@ -69,13 +69,13 @@ Run the following to push the above changes to the kops state store in S3.
 
 `kops update cluster`
 
-Review the changes before committing with: 
+Review the changes before committing with:
 
 `kops update cluster -yes`
 
 ### Perform a rolling-update
 
-This is a delicate procedure, so this article will proceed with extreme caution. 
+This is a delicate procedure, so this article will proceed with extreme caution.
 
 First, get the instance groups:
 
@@ -85,7 +85,7 @@ Update each master individually:
 
 `kops rolling-update cluster --instance-group <master-instance-group> (--yes)`
 
-Kops will safely eject the instance from the cluster and bring back a new one. 
+Kops will safely eject the instance from the cluster and bring back a new one.
 
 Once the new master is in a `ready` state, run the fast integration tests with:
 
@@ -117,7 +117,7 @@ kops create instancegroup nodes-<kubernetes-version>
 kops update cluster
 kops update cluster --yes
 ```
-note: we use the kubernetes-version to identify the new node group. 
+note: we use the kubernetes-version to identify the new node group.
 
 New instances will be created, which you'll see with:
 
@@ -139,7 +139,7 @@ We need to insert the following before each line in this file:
 
 `kubectl cordon`
 
-To do this quickly in vim I used: 
+To do this quickly in vim I used:
 
 ```
 qq shift+i “kubectl cordon ” esc j ^ q G@q
@@ -153,7 +153,7 @@ The ingress controllers play in important role in a live cluster. To ensure thes
 kubectl -n ingress-controllers edit deploy nginx-ingress-acme-controller
 ```
 
-And double the number of replicas. 
+And double the number of replicas.
 
 ### Drain the old worker nodes
 
@@ -173,7 +173,7 @@ and then
 
 at the end.
 
-To do this quickly in vim I used: 
+To do this quickly in vim I used:
 
 ```
 qq shift+i “kubectl drain ” esc shift+a “--ignore-daemonsets --delete-local-data” esc j ^ q G@q
@@ -197,7 +197,7 @@ kops validate cluster
 
 ### Run integration tests again
 
-Run the [integration test pipeline] and wait for the tests to pass. This will ensure you're live cluster is functioning as expected. 
+Run the [integration test pipeline] and wait for the tests to pass. This will ensure you're live cluster is functioning as expected.
 
 ### Delete the old instance group
 
@@ -205,7 +205,7 @@ When complete and all pods have migrated onto the new workers. Delete the older 
 
 ### Scale the ingress-controllers down
 
-We can now scale the ingress-controllers back down. 
+We can now scale the ingress-controllers back down.
 
 ```
 kubectl -n ingress-controllers edit deploy nginx-ingress-acme-controller
@@ -213,14 +213,14 @@ kubectl -n ingress-controllers edit deploy nginx-ingress-acme-controller
 
 ## Commit changes back to master
 
-Any changes made to the cloud-platform-infrastructure repository should be pushed for review. This includes manifest changes and image tag changes. 
+Any changes made to the cloud-platform-infrastructure repository should be pushed for review. This includes manifest changes and image tag changes.
 
 [infrastructure repo]: https://github.com/ministryofjustice/cloud-platform-infrastructure
 [integration test pipeline]: https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/integration-tests/jobs/apply-tests-live-1
-[cluster naming policy]: https://github.com/ministryofjustice/cloud-platform/blob/master/architecture-decision-record/009-Naming-convention-for-clusters.md
+[cluster naming policy]: https://github.com/ministryofjustice/cloud-platform/blob/main/architecture-decision-record/009-Naming-convention-for-clusters.md
 [AWS CLI]: https://aws.amazon.com/cli/
 [docker]: https://www.docker.com/
 [PagerDuty]: https://www.pagerduty.com/
 [tools image]: https://github.com/ministryofjustice/cloud-platform-tools-image
-[kube-system-ns]: https://github.com/ministryofjustice/cloud-platform-environments/blob/master/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/00-namespace.yaml
+[kube-system-ns]: https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/00-namespace.yaml
 

--- a/runbooks/source/upgrade-eks-cluster.html.md.erb
+++ b/runbooks/source/upgrade-eks-cluster.html.md.erb
@@ -24,11 +24,11 @@ Before you begin, there are a few pre-requisites:
 
 ## Run the upgrade
 
-### Upgrade Control Plane 
+### Upgrade Control Plane
 
 As we mentioned before: almost always new EKS version implies new [terraform-aws-eks module version](https://github.com/terraform-aws-modules/terraform-aws-eks). As an example, the following instructions were applied to upgrade from 1.14 to 1.15:
 
-1) Create a PR in Cloud Platform Infrastructure repo [against EKS module](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-eks/cluster.tf) (file encrypted with git-crypt to protect users identity) which upgrade to the desired [terraform-aws-eks version](https://github.com/terraform-aws-modules/terraform-aws-eks) that supports the EKS version you want to upgrade to
+1) Create a PR in Cloud Platform Infrastructure repo [against EKS module](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/cloud-platform-eks/cluster.tf) (file encrypted with git-crypt to protect users identity) which upgrade to the desired [terraform-aws-eks version](https://github.com/terraform-aws-modules/terraform-aws-eks) that supports the EKS version you want to upgrade to
 
 ```
  module "eks" {
@@ -48,7 +48,7 @@ $
 
 ![AWS Console](../images/aws-eks-upgrade.png)
 
-4) Most of the time new EKS version implies new versions for `kube-proxy`/`kube-dns`/`aws-node daemonset`. The upgrade process can be found directly in the official [AWS Control Plane upgrade documentation](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html) and **MUST BE FOLLOWED, PLEASE DON'T SKIP IT**. 
+4) Most of the time new EKS version implies new versions for `kube-proxy`/`kube-dns`/`aws-node daemonset`. The upgrade process can be found directly in the official [AWS Control Plane upgrade documentation](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html) and **MUST BE FOLLOWED, PLEASE DON'T SKIP IT**.
 
 ### Upgrade Node Groups
 

--- a/runbooks/source/velero.html.md.erb
+++ b/runbooks/source/velero.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Velero - Cluster backups and disaster recovery 
+title: Velero - Cluster backups and disaster recovery
 weight: 601
 last_reviewed_on: 2020-05-07
 review_in: 3 months
@@ -13,13 +13,13 @@ Velero consists of:
 - A server that runs on your cluster
 - A command-line client that runs locally
 
-#### Velero CLI Install: 
+#### Velero CLI Install:
 
 ```
 brew install velero
 ````
 
-Velero is installed on all clusters as part of the cloud-platform-components install. Click [here](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/velero.tf) to view the velero.tf file.
+Velero is installed on all clusters as part of the cloud-platform-components install. Click [here](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/cloud-platform-components/velero.tf) to view the velero.tf file.
 
 Velero is installed in `namespace:velero` using helm. The chart used can be found [here](https://github.com/helm/charts/tree/master/stable/velero)
 
@@ -51,13 +51,13 @@ There are hundreds of reasons why you need to backup parts and/or your full clus
 
 Velero can be used to back up as little as a single resource type to the whole cluster (all namespaces and resources).
 
-StatefulSets including corresponding persistent volumes are backed up together, as unlike stateless applications, it is not possible to easily get an application restored when it has persistent data. 
+StatefulSets including corresponding persistent volumes are backed up together, as unlike stateless applications, it is not possible to easily get an application restored when it has persistent data.
 
 Velero **does not** backup the Kubernetes state stored in etcd. It is highly recommenced that a specific backup solution is used for etcd and its relevant certificates in addition to Velero.
 
 ### How?
 
-It is possible to create manual backups as well as schedules ones. 
+It is possible to create manual backups as well as schedules ones.
 
 #### Manual backups
 
@@ -74,8 +74,8 @@ velero restore create --from-backup my-app-backup01
 
 #### Scheduled backups
 Currently there is one scheduled backup created as part of the default install.
-This schedule is called `velero-allnamespacebackup`. This backup includes all namespaces, resources and persistent volumes (EBS) associated with StatefulSets. 
-The Schedule is set to run every 3 hours. 
+This schedule is called `velero-allnamespacebackup`. This backup includes all namespaces, resources and persistent volumes (EBS) associated with StatefulSets.
+The Schedule is set to run every 3 hours.
 
 To view all stored backups within the cluster, run the following command:
 
@@ -115,4 +115,4 @@ kubectl patch backupstoragelocation <STORAGE LOCATION NAME> \
 ```
 
 
-Click [here](https://velero.io/docs/v1.2.0/) for the official Velero documentation. 
+Click [here](https://velero.io/docs/v1.2.0/) for the official Velero documentation.


### PR DESCRIPTION
We have a lot of links to our github repos, in the
runbooks. This PR updates those links to point to
the "main" branch, rather than master.