### PR TITLE
Set "main" as target branch of "View Source" links

### DIFF
--- a/runbooks/config/tech-docs.yml
+++ b/runbooks/config/tech-docs.yml
@@ -36,6 +36,7 @@ prevent_indexing: true
 
 show_contribution_banner: true
 github_repo: ministryofjustice/cloud-platform
+github_branch: "main"
 
 owner_slack_workspace: mojdt
 default_owner_slack: '#cloud-platform'


### PR DESCRIPTION
All the "View Source" links at the foot of each page are currently
broken because the default target includes "master" as the branch name.
This change fixes that.