### PR TITLE
Correct front-matter & remove "INTERNAL"

### DIFF
--- a/runbooks/config/tech-docs.yml
+++ b/runbooks/config/tech-docs.yml
@@ -5,7 +5,6 @@ host: https://runbooks.cloud-platform.service.justice.gov.uk
 show_govuk_logo: false
 service_name: Cloud Platform Runbooks
 service_link: /
-phase: INTERNAL
 
 # Links to show on right-hand-side of header
 header_links:

--- a/runbooks/source/index.html.md.erb
+++ b/runbooks/source/index.html.md.erb
@@ -5,4 +5,4 @@ weight: 1
 
 # Cloud Platform Runbooks
 
-Published via CircleCI
+These runbooks are used and maintained by the MoJ Digital Cloud Platform team.


### PR DESCRIPTION
The runbooks site has an "INTERNAL" phase label on it, which shouldn't be there (since it's a publicly-viewable document)