### PR TITLE
kops variable is not needed here

### DIFF
--- a/runbooks/source/access-eks-cluster.html.md.erb
+++ b/runbooks/source/access-eks-cluster.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Access EKS Cluster
 weight: 8600
-last_reviewed_on: 2020-04-27
+last_reviewed_on: 2020-07-28
 review_in: 3 months
 ---
 
@@ -16,7 +16,6 @@ In order for kubectl to find and access a EKS cluster, it needs a kubeconfig fil
 - Set your environment variables
 
 ```
-    export KOPS_STATE_STORE=s3://cloud-platform-kops-state
     export AWS_PROFILE=moj-cp
 ```
 


### PR DESCRIPTION
Updated "Access EKS cluster" documentation.

Removed `KOPS_STATE_STORE` variable, it isn't needed within this doc.