### PR TITLE
Add user guide link on main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ reduce duplicates and encourage activity on existing conversations.
 
  * [Architecture Decision Records](architecture-decision-record)
  * [Runbooks]
+ * [User Guide]
 
 ## Cloud platform repo list
 
@@ -67,3 +68,4 @@ We have a series of repositories for our work that we have listed below. We have
 [rds-port-forward]: https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance#access-outside-the-cluster
 [environments repository]: https://github.com/ministryofjustice/cloud-platform-environments
 [Runbooks]: https://runbooks.cloud-platform.service.justice.gov.uk
+[User Guide]: https://user-guide.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
It seems strange that we linked from here to ADRs and Runbooks, but not to our user guide.