### PR TITLE
Restrict filepaths for runbooks publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,11 @@
-name: Publish
+name: Publish runbooks
 
 on:
   push:
     branches:
       - "main"
+    paths:
+      - "runbooks/**"
 
 jobs:
   run:


### PR DESCRIPTION
If the runbooks publishing action runs on a change which doesn't alter
the files below runbooks/, it fails.

Also, change the title of the github action to make its purpose clearer.