### PR TITLE
Rename "Replacing a master node" to "Replacing a failed master node"

### DIFF
--- a/runbooks/source/replacing-failed-master-node.html.md.erb
+++ b/runbooks/source/replacing-failed-master-node.html.md.erb
@@ -1,11 +1,11 @@
 ---
-title: Replacing a master node
+title: Replacing a failed master node
 weight: 225
 last_reviewed_on: 2020-05-06
 review_in: 3 months
 ---
 
-# Replacing a master node
+# Replacing a failed master node
 
 If one of the master nodes fails due to hardware failure, data directory corruption, etcd volume deletion, or some other problem, it should be replaced as soon as possible.
 


### PR DESCRIPTION
This run-book is used when there is a master node failure(disaster scenario),
renamed it to avoid confusion of considering this as recycling master node.