### PR TITLE
Revert "Update kramdown gem to 2.3.0"

### DIFF
--- a/runbooks/Gemfile.lock
+++ b/runbooks/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    kramdown (2.3.0)
+    kramdown (1.17.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform#2196

I was wrong about this change not affecting anything - it breaks the runbooks publishing process.