### PR TITLE
Remove review metadata from incident log

### DIFF
--- a/runbooks/source/incident-log.html.md.erb
+++ b/runbooks/source/incident-log.html.md.erb
@@ -1,8 +1,6 @@
 ---
 title: Incident Log
 weight: 45
-last_reviewed_on: 2020-05-13
-review_in: 3 months
 ---
 
 # Incident Log


### PR DESCRIPTION
As a record of past events, it's not necessary to keep reviewing this document.