### PR TITLE
Replace the real-looking AWS access key with XXX

### DIFF
--- a/runbooks/source/rotate-user-aws-credentials.html.md.erb
+++ b/runbooks/source/rotate-user-aws-credentials.html.md.erb
@@ -59,19 +59,19 @@ The final `terraform plan` should output `No changes. Infrastructure is up-to-da
 $ terraform show | less
 ```
 
-Look for the compromised access key. In this case, the access key was AKIA27HJSWAHHIG5ACYA, and it occurs in two places in the output.
+Look for the compromised access key. In this case, the access key was AKIAXXXXXXXXXXXXXXXX, and it occurs in two places in the output.
 
 ```
 ...
 kubernetes_secret.ecr-repo-my-repo:
   id = my-namespace/ecr-repo-my-repo
   data.% = 3
-  data.access_key_id = AKIA27HJSWAHHIG5ACYA
+  data.access_key_id = AKIAXXXXXXXXXXXXXXXX
   data.repo_url = ...
   data.secret_access_key = ...
 ...
 module.ecr-repo-my-repo.aws_iam_access_key.key:
-  id = AKIA27HJSWAHHIG5ACYA
+  id = AKIAXXXXXXXXXXXXXXXX
   secret = ...
   ses_smtp_password = ...
 ...
@@ -120,7 +120,7 @@ Terraform will perform the following actions:
 
   ~ kubernetes_secret.ecr-repo-my-repo
       data.%:                 "" => <computed>
-      data.access_key_id:     "AKIA27HJSWAHHIG5ACYA" => ""
+      data.access_key_id:     "AKIAXXXXXXXXXXXXXXXX" => ""
       data.repo_url:          "..." => ""
       data.secret_access_key: "..." => ""
 


### PR DESCRIPTION
We had an AWS access key in this runbook page which looked like a real
access key, even though it was not valid. This means we get spammed by
GitGuardian every week, alerting us about a leaked credential. This is
annoying, and means that we'd be less likely to pay attention to a
genuine credential-leak alert message.

I'm hoping this PR will fix that.
