### PR TITLE
Standardize bullets formatting and a couple of minor changes

### DIFF
--- a/runbooks/source/incident-log.html.md.erb
+++ b/runbooks/source/incident-log.html.md.erb
@@ -25,18 +25,18 @@ weight: 45
 - **Incident**: The Ingress API refused 100% of POST requests.
 
 - **Impact**:
-    - If a user were to provision a new service, they would be unable to create an ingress into the cluster.
+  - If a user were to provision a new service, they would be unable to create an ingress into the cluster.
 
 - **Context**:
-  * [Version 0.1.0](https://github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller/compare/0.0.9...0.1.0) of the [teams ingress controller module](https://github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller) enabled the creation of a `validationwebhookconfiguration` resource.
-  * By enabling this option we created a single point of failure for all ingress-controller pods in the `ingress-controller` namespace.
-  * A new 0.1.0 ingress controller failed to create in the "live-1" cluster due to AWS resource limits.
-  * Validation webhook stopped new rules from creating, with the error:
-  ```
-  Error from server (InternalError): error when creating "ingress.yaml": Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": Post https://offender-categorisation-prod-nx-controller-admission.ingress-controllers.svc:443/extensions/v1beta1/ingresses?timeout=30s: x509: certificate signed by unknown authority
-  ```
-  * Initial investigation thread: https://mojdt.slack.com/archives/C514ETYJX/p1599478794246900
-  * Incident declared: https://mojdt.slack.com/archives/C514ETYJX/p1599479640251900
+  - [Version 0.1.0](https://github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller/compare/0.0.9...0.1.0) of the [teams ingress controller module](https://github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller) enabled the creation of a `validationwebhookconfiguration` resource.
+  - By enabling this option we created a single point of failure for all ingress-controller pods in the `ingress-controller` namespace.
+  - A new 0.1.0 ingress controller failed to create in the "live-1" cluster due to AWS resource limits.
+  - Validation webhook stopped new rules from creating, with the error:
+    ```
+    Error from server (InternalError): error when creating "ingress.yaml": Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": Post https://offender-categorisation-prod-nx-controller-admission.ingress-controllers.svc:443/extensions/v1beta1/ingresses?timeout=30s: x509: certificate signed by unknown authority
+    ```
+  - Initial investigation thread: https://mojdt.slack.com/archives/C514ETYJX/p1599478794246900
+  - Incident declared: https://mojdt.slack.com/archives/C514ETYJX/p1599479640251900
 
 - **Resolution**:
     The team manually removed the all the additional admission controllers created by 0.1.0. They then removed the admission webhook from the module and created a new release (0.1.1). All ingress modules currently on 0.1.0 were upgraded to the new release 0.1.1.
@@ -55,15 +55,15 @@ weight: 45
 - **Incident**: The AWS  Availability Zones `eu-west-2a`, which contain some of our kubernetes nodes had an outage. API latency was elevated, some EC2 became unreachable and overall connectivity was unstable.
 
 - **Impact**:  
-    - Two kubernetes nodes became unreachable
-    - No new node could be launched in eu-west-2a 
-    - Kubernetes had issues talking to some of these nodes, preventing some API calls to succeed (Pods were not terminating)
-    - New pods were not able to pull their Docker images.
+  - Two kubernetes nodes became unreachable
+  - No new node could be launched in eu-west-2a 
+  - Kubernetes had issues talking to some of these nodes, preventing some API calls to succeed (Pods were not terminating)
+  - New pods were not able to pull their Docker images.
 
 - **Context**:
-    * Pods and Nodes sitting in other Availability Zones (b & c) were not impacted
-    * Slack threads: [Issue detected](https://mojdt.slack.com/archives/C514ETYJX/p1598351210195200), [Incident Declared](https://mojdt.slack.com/archives/C514ETYJX/p1598351210195200),
-    * We now have 25 pods in the cluster, instead of 21
+  - Pods and Nodes sitting in other Availability Zones (b & c) were not impacted
+  - Slack threads: [Issue detected](https://mojdt.slack.com/archives/C514ETYJX/p1598351210195200), [Incident Declared](https://mojdt.slack.com/archives/C514ETYJX/p1598351210195200),
+  - We now have 25 pods in the cluster, instead of 21
 
 - **Resolution**:
     The incident was mitigated by deploying more 2-4 nodes in healthy Availability Zones, manually deleting the non-responding pods, and terminating the impacted nodes
@@ -82,14 +82,14 @@ weight: 45
 - **Incident**: There are 6 replicas of the ingress-controller pod and 2 out of the 6 were crashlooping. A restart of the pods did not resolve the issue. As per a normal runbook process, a recycle of all pods was required. However after restarting pods 4 and 5, they also started to crashloop. The risk was when restarting pods 5 and 6 -  all 6 pods could be down and all ingresses down for the cluster.
 
 - **Impact**:
-    - Increased risk for all ingresses failing in the cluster if all 6 ingress-controller pods are in a crashloop state.
+  - Increased risk for all ingresses failing in the cluster if all 6 ingress-controller pods are in a crashloop state.
 
 - **Context**:
-    * 2 of the 6 ingress-controller pods crashlooping, after restart of 4 pods, 4 out of 6 pods crashlooping.
-    * Issue was with the leader ingress-controller pod (which was not identified or restarted yet) and exhausting the shared memory.
-    * After a restart of the leader ingress-controller pod, all other pods reverted back to a ready/running state.
-    * Timeline : [https://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/edit#heading=h.z3py6eydx4qu](https://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/edit#heading=h.z3py6eydx4qu)
-    * Slack thread: [https://mojdt.slack.com/archives/C514ETYJX/p1597399295031000](https://mojdt.slack.com/archives/C514ETYJX/p1597399295031000),
+  - 2 of the 6 ingress-controller pods crashlooping, after restart of 4 pods, 4 out of 6 pods crashlooping.
+  - Issue was with the leader ingress-controller pod (which was not identified or restarted yet) and exhausting the shared memory.
+    - After a restart of the leader ingress-controller pod, all other pods reverted back to a ready/running state.
+    - Timeline : [https://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/edit#heading=h.z3py6eydx4qu](https://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/edit#heading=h.z3py6eydx4qu)
+    - Slack thread: [https://mojdt.slack.com/archives/C514ETYJX/p1597399295031000](https://mojdt.slack.com/archives/C514ETYJX/p1597399295031000),
 
 - **Resolution**:
     A restart of the leader ingress-controller pod was required so the other pods in the replica-set could connect and get the latest nginx.config file.
@@ -109,19 +109,19 @@ weight: 45
 - **Incident**: Routine replacement of a master node failed because AWS did not have any c4.4xlarge instances available in the relevant availability zone.
 
 - **Impact**:
-    - Increased risk because the cluster was running on 2 out of 3 master nodes, for a brief period
+  - Increased risk because the cluster was running on 2 out of 3 master nodes, for a brief period
 
 - **Context**:
-    * Lack of availability of a given instance type is not a failure mode for which we have planned
-    * In theory, if a problem occurs which eventually kills each master node in turn, and if instances of the right type are not available in at least 2 availability zones, this could bring down the whole cluster.
-    * Timeline : [https://docs.google.com/document/d/1SOAOeL-89cuK-_fJbtgYcArInWQY7UXiIDY7wN5gjuA/edit#](https://docs.google.com/document/d/1SOAOeL-89cuK-_fJbtgYcArInWQY7UXiIDY7wN5gjuA/edit#)
+  - Lack of availability of a given instance type is not a failure mode for which we have planned
+  - In theory, if a problem occurs which eventually kills each master node in turn, and if instances of the right type are not available in at least 2 availability zones, this could bring down the whole cluster.
+  - Timeline : [https://docs.google.com/document/d/1SOAOeL-89cuK-_fJbtgYcArInWQY7UXiIDY7wN5gjuA/edit#](https://docs.google.com/document/d/1SOAOeL-89cuK-_fJbtgYcArInWQY7UXiIDY7wN5gjuA/edit#)
 ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/edit#heading=h.z3py6eydx4qu)
-    * Slack thread: [https://mojdt.slack.com/archives/C514ETYJX/p1596814746202600](https://mojdt.slack.com/archives/C514ETYJX/p1596814746202600)
+  - Slack thread: [https://mojdt.slack.com/archives/C514ETYJX/p1596814746202600](https://mojdt.slack.com/archives/C514ETYJX/p1596814746202600)
 
 - **Resolution**:
-    * A new c4.4xlarge node *was* successfully (and automatically) launched approx. 40 minutes after we saw the problem
-    * We replaced all our master nodes with c5.4xlarge instances, which (currently) have better availability
-    * We and AWS are still investigating longer-term and more reliable fixes
+  - A new c4.4xlarge node *was* successfully (and automatically) launched approx. 40 minutes after we saw the problem
+  - We replaced all our master nodes with c5.4xlarge instances, which (currently) have better availability
+  - We and AWS are still investigating longer-term and more reliable fixes
 
 ## Q2 2020 (April - June)
 
@@ -145,14 +145,14 @@ ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/e
  divergence pipeline shows drift for live-1 components
 
 - **Impact**:
-    - Increased risk for cluster failure because some of the components do not have the correct configuration needed for the `live-1` production cluster
+  - Increased risk for cluster failure because some of the components do not have the correct configuration needed for the `live-1` production cluster
 
 - **Context**:
-    * One of the engineers was creating a test EKS cluster and ran `terraform apply` on EKS components
-    * Without fully aware of the current cluster context, the `terraform apply` for EKS test cluster components has been applied to the `live-1` kops cluster
-    * This has changed the configuration of several resources in the `live-1` cluster
-    * Timeline : [https://docs.google.com/document/d/1VrABxeHLMOnoM4yYoCi9N4N4zRY1SK1hTjrZ9s05zuc/edit?usp=sharing](https://docs.google.com/document/d/1VrABxeHLMOnoM4yYoCi9N4N4zRY1SK1hTjrZ9s05zuc/edit?usp=sharing)
-    * Slack thread: [https://mojdt.slack.com/archives/C514ETYJX/p1596621864015400](https://mojdt.slack.com/archives/C514ETYJX/p1596621864015400),
+  - One of the engineers was creating a test EKS cluster and ran `terraform apply` on EKS components
+  - Without fully aware of the current cluster context, the `terraform apply` for EKS test cluster components has been applied to the `live-1` kops cluster
+  - This has changed the configuration of several resources in the `live-1` cluster
+  - Timeline : [https://docs.google.com/document/d/1VrABxeHLMOnoM4yYoCi9N4N4zRY1SK1hTjrZ9s05zuc/edit?usp=sharing](https://docs.google.com/document/d/1VrABxeHLMOnoM4yYoCi9N4N4zRY1SK1hTjrZ9s05zuc/edit?usp=sharing)
+  - Slack thread: [https://mojdt.slack.com/archives/C514ETYJX/p1596621864015400](https://mojdt.slack.com/archives/C514ETYJX/p1596621864015400),
 
 - **Resolution**:
     Compare each resource configuration with the terraform state and applied the correct configuration from the code specific to kops cluster
@@ -174,18 +174,18 @@ ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/e
 - **Incident**: After an upgrade of the Nginx ingresses, support for legacy TLS was dropped.
 
 - **Impact**:
-    - IE11 users could not access any services running on the Cloud Platform
-    - A few teams came forward with the issue :
-    --- LAA
-    --- Correspondence Tool
-    --- Prisoner Money
+  - IE11 users could not access any services running on the Cloud Platform
+  - A few teams came forward with the issue :
+    - LAA
+    - Correspondence Tool
+    - Prisoner Money
 
 - **Context**:
-    * After an upgrade of the Nginx Helm chart v1.24.0 to v1.35
-    * The current version of Nginx has deprecated support for TLS < 1.3
-    * The issue was spotted on IE11 browsers.
-    * Timeline : [https://docs.google.com/document/d/1SCf1WT82IlBYWozWN_FXZqL5h0KUcul_QAkxE84YDw0/edit?usp=sharing](https://docs.google.com/document/d/1SCf1WT82IlBYWozWN_FXZqL5h0KUcul_QAkxE84YDw0/edit?usp=sharing)
-    * Slack thread: [https://mojdt.slack.com/archives/C57UPMZLY/p1586954463298700](https://mojdt.slack.com/archives/C57UPMZLY/p1586954463298700)
+  - After an upgrade of the Nginx Helm chart v1.24.0 to v1.35
+  - The current version of Nginx has deprecated support for TLS < 1.3
+  - The issue was spotted on IE11 browsers.
+  - Timeline : [https://docs.google.com/document/d/1SCf1WT82IlBYWozWN_FXZqL5h0KUcul_QAkxE84YDw0/edit?usp=sharing](https://docs.google.com/document/d/1SCf1WT82IlBYWozWN_FXZqL5h0KUcul_QAkxE84YDw0/edit?usp=sharing)
+  - Slack thread: [https://mojdt.slack.com/archives/C57UPMZLY/p1586954463298700](https://mojdt.slack.com/archives/C57UPMZLY/p1586954463298700)
 
 - **Resolution**:
     The Nginx configuration was modified to enable TLSv1, TLSv1.1 and TLSv1.2
@@ -212,14 +212,14 @@ ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/e
 - **Incident**: During an upgrade, new masters were not coming up correctly (missing calico networking and other pods)
 
 - **Impact**:
-    - Degraded kubernetes API performance (because some API calls were being directed to non-functioning masters)
-    - Increased risk of cluster failure, because we were running on a single master during the incident
+  - Degraded kubernetes API performance (because some API calls were being directed to non-functioning masters)
+  - Increased risk of cluster failure, because we were running on a single master during the incident
 
 - **Context**:
-    * Upgrading from kubernetes 1.13.12 to 1.14.10, kops 1.13.2 to 1.14.1
-    * The first master was replaced fine, but the second didn't have calico and some other essential pods, and was not functioning correctly
-    * Attempting to roll back the upgrade, every new master exhibited the same problem
-    * Slack thread: [https://mojdt.slack.com/archives/C514ETYJX/p1582628309085600](https://mojdt.slack.com/archives/C514ETYJX/p1582628309085600)
+  - Upgrading from kubernetes 1.13.12 to 1.14.10, kops 1.13.2 to 1.14.1
+  - The first master was replaced fine, but the second didn't have calico and some other essential pods, and was not functioning correctly
+  - Attempting to roll back the upgrade, every new master exhibited the same problem
+  - Slack thread: [https://mojdt.slack.com/archives/C514ETYJX/p1582628309085600](https://mojdt.slack.com/archives/C514ETYJX/p1582628309085600)
 
 - **Resolution**:
     The `kube-system` namespace has a label, `openpolicyagent.org/webhook: ignore` This label tells the Open Policy Agent (OPA) that pods are allowed to run in this namespace on the master nodes. Somehow, this label got removed, so the OPA was preventing pods from running on the new master nodes, as each one came up, so the new master was unable to launch essential pods such as `calico` and `fluentd`.
@@ -238,15 +238,15 @@ ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/e
 - **Incident**: Pingdom reported that Prometheus was down (prometheus.cloud-platform.service.justice.gov.uk).
 
 - **Impact**:
-    - The prometheus dashboard was unavailable for everyone, for the whole duration of the incident.
-    - Between 2020-02-18 14:22 and 2020-02-18 14:26, prometheus could not receive metrics.
+  - The prometheus dashboard was unavailable for everyone, for the whole duration of the incident.
+  - Between 2020-02-18 14:22 and 2020-02-18 14:26, prometheus could not receive metrics.
 
 - **Context**:
-   - Although the Prometheus URL was unreachable, Grafana and Alertmanager were resolving.
-   - There seemed to be an issue preventing requests to reach the prometheus pods.
-   - Disk space and other resources, the usual suspects, were ruled out as the cause.
-   - The domain name amd ingress were both valid.
-   - Slack thread: <https://mojdt.slack.com/archives/C514ETYJX/p1582035803248800>
+  - Although the Prometheus URL was unreachable, Grafana and Alertmanager were resolving.
+  - There seemed to be an issue preventing requests to reach the prometheus pods.
+  - Disk space and other resources, the usual suspects, were ruled out as the cause.
+  - The domain name amd ingress were both valid.
+  - Slack thread: <https://mojdt.slack.com/archives/C514ETYJX/p1582035803248800>
 
 - **Resolution**:
     We suspect an intermittent & external networking issue to be the cause of this outage.
@@ -265,25 +265,27 @@ ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/e
 
 - **Identified**: Pingdom reported Concourse (concourse.cloud-platform.service.justice.gov.uk) down.
 
-- **Context**: One of the engineers was deleting old clusters (he ran `terraform destroy`) and he wasn't fully aware in which _terraform workspace_ was working on. Using `terraform destroy`, EKS nodes/workers were deleted from the manager cluster.
+- **Context**:
+  - One of the engineers was deleting old clusters (he ran `terraform destroy`) and he wasn't fully aware in which _terraform workspace_ was working on. Using `terraform destroy`, EKS nodes/workers were deleted from the manager cluster.
+  - Slack thread: <https://mojdt.slack.com/archives/C514ETYJX/p1581508273080900>
 
-- **Resolution**: Using terraform (`terraform apply -var-file vars/manager.tfvars` specifically) the cluster nodes where created and the infrastructure aligned? to the desired terraform state
+  - **Resolution**: Using terraform (`terraform apply -var-file vars/manager.tfvars` specifically) the cluster nodes where created and the infrastructure aligned? to the desired terraform state
 
 
-# About this incident log
+## About this incident log
 
 The purpose of publishing this incident log:
 
-* for the Cloud Platform team to learn from incidents
-* for the Cloud Platform team and its stakeholders to track incident trends and performance
-* because we operate in the open
+- for the Cloud Platform team to learn from incidents
+- for the Cloud Platform team and its stakeholders to track incident trends and performance
+- because we operate in the open
 
 Definitions:
 
-* The words used in the timeline of an incident: fault occurs, team becomes aware (of something bad), incident declared (the team acknowledges and has an idea of the impact), repaired (system is fully functional), resolved (fully functional and future failures are prevented)
-* *Incident time* - The start of the failure (Before March 2020 it was the time the incident was declared)
-* *Time to Repair* - (Used only up to March 2020) The time between the incident being declared and when service is fully restored. Only includes [Hours of Support](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/reference/operational-processes.html#hours-of-support).
-* *Time to Resolve* - The time between when the fault occurs and when system is fully functional (and include any immediate work done to prevent future failures). Only includes [Hours of Support](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/reference/operational-processes.html#hours-of-support). This is a broader metric of incident response performance, compared to Time to Repair.
+- The words used in the timeline of an incident: fault occurs, team becomes aware (of something bad), incident declared (the team acknowledges and has an idea of the impact), repaired (system is fully functional), resolved (fully functional and future failures are prevented)
+- *Incident time* - The start of the failure (Before March 2020 it was the time the incident was declared)
+- *Time to Repair* - The time between the incident being declared and when service is fully restored. Only includes [Hours of Support](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/reference/operational-processes.html#hours-of-support).
+- *Time to Resolve* - The time between when the fault occurs and when system is fully functional (and include any immediate work done to prevent future failures). Only includes [Hours of Support](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/reference/operational-processes.html#hours-of-support). This is a broader metric of incident response performance, compared to Time to Repair.
 
 Source: [Atlassian](https://www.atlassian.com/incident-management/kpis/common-metrics)
 


### PR DESCRIPTION
My linter is going crazy with the flipping between `*` and `-` as bullet chars, and 2 vs 4 indentation, so I just plumped for `-` and 2 spaces.