### PR TITLE
Make the incident log formatting consistent & add metrics script

### DIFF
--- a/runbooks/bin/mean-time-to-repair.rb
+++ b/runbooks/bin/mean-time-to-repair.rb
@@ -2,7 +2,9 @@
 
 # Consume the incident log file and output incident performance metrics
 #
-#   Usage: ./mean_time_to_repair.rb
+#   Usage (from inside the `runbooks/source` directory):
+#
+#     ../bin/mean_time_to_repair.rb
 #
 
 require "date"

--- a/runbooks/source/incident-log.html.md.erb
+++ b/runbooks/source/incident-log.html.md.erb
@@ -51,7 +51,7 @@ weight: 45
   - Repaired 2020-09-28 14:20
   - Resolved 2020-09-28 14:44
 
-- **Time to repair**: 15m
+- **Time to repair**: 0h 15m
 
 - **Time to resolve**: 1h 30m
 
@@ -81,7 +81,7 @@ weight: 45
   - Repaired 2020-09-21 19:05
   - Resolved 2020-09-21 21:41
 
-- **Time to repair**: 38m
+- **Time to repair**: 0h 38m
 
 - **Time to resolve**: 3h 14m
 
@@ -144,7 +144,7 @@ weight: 45
   - Incident declared 2020-08-25 11:26
   - Resolved 2020-08-25 12:11
 
-- **Time to repair**: 45m
+- **Time to repair**: 0h 45m
 
 - **Time to resolve**: 1h 10m
 
@@ -171,9 +171,9 @@ weight: 45
   - Incident declared 2020-08-14 11:01
   - Resolved 2020-08-14 11:38
 
-- **Time to repair**: 37m
+- **Time to repair**: 0h 37m
 
-- **Time to resolve**: 55m
+- **Time to resolve**: 0h 55m
 
 - **Identified**: There are 6 replicas of the ingress-controller pod and 2 out of the 6 were crashlooping. A restart of the pods did not resolve the issue. As per a normal runbook process, a recycle of all pods was required. However after restarting pods 4 and 5, they also started to crashloop. The risk was when restarting pods 5 and 6 -  all 6 pods could be down and all ingresses down for the cluster.
 
@@ -198,7 +198,7 @@ weight: 45
   - Incident declared 2020-08-07 16:39
   - Resolved 2020-08-14 10:06
 
-- **Time to repair**: 38m
+- **Time to repair**: 0h 38m
 
 - **Time to resolve**: 33h 15m (during support hours 10:00-17:00 M-F)
 
@@ -263,7 +263,7 @@ ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/e
 
 - **Status**: Resolved at 2020-04-15 15:09 UTC
 
-- **Time to repair**: 30m
+- **Time to repair**: 0h 30m
 
 - **Time to resolve**: 5h 09m (during support hours 10:00-17:00)
 
@@ -327,9 +327,9 @@ ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/e
   - Incident declared 2020-02-18 14:23
   - Resolved 2020-02-18 14:59
 
-- **Time to repair**: 36m
+- **Time to repair**: 0h 36m
 
-- **Time to recovery**: 46m
+- **Time to resolve**: 0h 46m
 
 - **Identified**: Pingdom reported that Prometheus was down (prometheus.cloud-platform.service.justice.gov.uk).
 
@@ -355,9 +355,9 @@ ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/e
   - Incident declared 2020-02-12 11:51
   - Resolved 2020-02-12 12:07
 
-- **Time to repair**: 16m
+- **Time to repair**: 0h 16m
 
-- **Time to recovery**: 22m
+- **Time to resolve**: 0h 22m
 
 - **Identified**: Pingdom reported Concourse (concourse.cloud-platform.service.justice.gov.uk) down.
 
@@ -394,9 +394,9 @@ Datestamps: please use `YYYY-MM-DD HH:MM` (almost ISO 8601, but more readable), 
 - **Key events**
   -
 
-- **Time to repair**: 0h 0m
+- **Time to repair**: Xh Xm
 
-- **Time to resolve**: 0h 0m
+- **Time to resolve**: Xh Xm
 
 - **Identified**:
 

--- a/runbooks/source/incident-log.html.md.erb
+++ b/runbooks/source/incident-log.html.md.erb
@@ -55,7 +55,7 @@ weight: 45
 
 - **Time to resolve**: 1h 30m
 
-- **Incident**: Periods of downtime while the cloud-platform team was applying per Availability Zone instance groups for worker nodes change in live-1. Failures caused mainly due to termination of a group of 9 nodes and letting kops to handle the cycling of pods, which took very long time for the new containers to be created in the new node group.
+- **Identified**: Periods of downtime while the cloud-platform team was applying per Availability Zone instance groups for worker nodes change in live-1. Failures caused mainly due to termination of a group of 9 nodes and letting kops to handle the cycling of pods, which took very long time for the new containers to be created in the new node group.
 
 - **Impact**:
   - Some users noticed cycling of pods but taking a long time for the containers to be created.
@@ -85,7 +85,7 @@ weight: 45
 
 - **Time to resolve**: 3h 14m
 
-- **Incident**: Some components of our production kubernetes cluster (live-1) were accidentally deleted, this caused some services running on cloud-platform gone down.
+- **Identified**: Some components of our production kubernetes cluster (live-1) were accidentally deleted, this caused some services running on cloud-platform gone down.
 
 - **Impact**:
   - Some users could not access services running on the Cloud Platform.
@@ -109,7 +109,7 @@ weight: 45
 
 ### Incident on 2020-09-07 12:54 - All users are unable to create new ingress rules
 
-- **Key times**
+- **Key events**
   - First detected 2020-09-07 12:39
   - Incident declared 2020-09-07 12:54
   - Resolved 2020-09-07 15:56
@@ -118,7 +118,7 @@ weight: 45
 
 - **Time to resolve**: 3h 17m
 
-- **Incident**: The Ingress API refused 100% of POST requests.
+- **Identified**: The Ingress API refused 100% of POST requests.
 
 - **Impact**:
   - If a user were to provision a new service, they would be unable to create an ingress into the cluster.
@@ -148,7 +148,7 @@ weight: 45
 
 - **Time to resolve**: 1h 10m
 
-- **Incident**: The AWS  Availability Zones `eu-west-2a`, which contain some of our kubernetes nodes had an outage. API latency was elevated, some EC2 became unreachable and overall connectivity was unstable.
+- **Identified**: The AWS  Availability Zones `eu-west-2a`, which contain some of our kubernetes nodes had an outage. API latency was elevated, some EC2 became unreachable and overall connectivity was unstable.
 
 - **Impact**:
   - Two kubernetes nodes became unreachable
@@ -175,7 +175,7 @@ weight: 45
 
 - **Time to resolve**: 55m
 
-- **Incident**: There are 6 replicas of the ingress-controller pod and 2 out of the 6 were crashlooping. A restart of the pods did not resolve the issue. As per a normal runbook process, a recycle of all pods was required. However after restarting pods 4 and 5, they also started to crashloop. The risk was when restarting pods 5 and 6 -  all 6 pods could be down and all ingresses down for the cluster.
+- **Identified**: There are 6 replicas of the ingress-controller pod and 2 out of the 6 were crashlooping. A restart of the pods did not resolve the issue. As per a normal runbook process, a recycle of all pods was required. However after restarting pods 4 and 5, they also started to crashloop. The risk was when restarting pods 5 and 6 -  all 6 pods could be down and all ingresses down for the cluster.
 
 - **Impact**:
   - Increased risk for all ingresses failing in the cluster if all 6 ingress-controller pods are in a crashloop state.
@@ -202,7 +202,7 @@ weight: 45
 
 - **Time to resolve**: 33h 15m (during support hours 10:00-17:00 M-F)
 
-- **Incident**: Routine replacement of a master node failed because AWS did not have any c4.4xlarge instances available in the relevant availability zone.
+- **Identified**: Routine replacement of a master node failed because AWS did not have any c4.4xlarge instances available in the relevant availability zone.
 
 - **Impact**:
   - Increased risk because the cluster was running on 2 out of 3 master nodes, for a brief period
@@ -237,7 +237,7 @@ ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/e
 
 - **Time to resolve**: 9h 16m (during support hours 10:00-17:00)
 
-- **Incident**: Integration tests failed for cert-manager, apply pipeline failed showing it doesnot have permissions and
+- **Identified**: Integration tests failed for cert-manager, apply pipeline failed showing it doesnot have permissions and
  divergence pipeline shows drift for live-1 components
 
 - **Impact**:
@@ -267,7 +267,7 @@ ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/e
 
 - **Time to resolve**: 5h 09m (during support hours 10:00-17:00)
 
-- **Incident**: After an upgrade of the Nginx ingresses, support for legacy TLS was dropped.
+- **Identified**: After an upgrade of the Nginx ingresses, support for legacy TLS was dropped.
 
 - **Impact**:
   - IE11 users could not access any services running on the Cloud Platform
@@ -305,7 +305,7 @@ ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/e
 
 - **Time to resolve**: 7h (during support hours 10:00-17:00)
 
-- **Incident**: During an upgrade, new masters were not coming up correctly (missing calico networking and other pods)
+- **Identified**: During an upgrade, new masters were not coming up correctly (missing calico networking and other pods)
 
 - **Impact**:
   - Degraded kubernetes API performance (because some API calls were being directed to non-functioning masters)
@@ -331,7 +331,7 @@ ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/e
 
 - **Time to recovery**: 46m
 
-- **Incident**: Pingdom reported that Prometheus was down (prometheus.cloud-platform.service.justice.gov.uk).
+- **Identified**: Pingdom reported that Prometheus was down (prometheus.cloud-platform.service.justice.gov.uk).
 
 - **Impact**:
   - The prometheus dashboard was unavailable for everyone, for the whole duration of the incident.

--- a/runbooks/source/incident-log.html.md.erb
+++ b/runbooks/source/incident-log.html.md.erb
@@ -413,4 +413,4 @@ Datestamps: please use `YYYY-MM-DD HH:MM` (almost ISO 8601, but more readable), 
 - **Resolution**:
   -
 
-  [mean-time-to-repair.rb]: https://github.com/ministryofjustice/cloud-platform/blob/main/runbooks/source/mean-time-to-repair.rb
+  [mean-time-to-repair.rb]: https://github.com/ministryofjustice/cloud-platform/blob/main/runbooks/bin/mean-time-to-repair.rb

--- a/runbooks/source/incident-log.html.md.erb
+++ b/runbooks/source/incident-log.html.md.erb
@@ -5,6 +5,8 @@ weight: 45
 
 # Incident Log
 
+> Use the [mean-time-to-repair.rb] script to view performance metrics
+
 ## Q4 2020 (October - December)
 
 - **Mean Time to repair**: 2h 8m
@@ -410,3 +412,5 @@ Datestamps: please use `YYYY-MM-DD HH:MM` (almost ISO 8601, but more readable), 
 
 - **Resolution**:
   -
+
+  [mean-time-to-repair.rb]: https://github.com/ministryofjustice/cloud-platform/blob/main/runbooks/source/mean-time-to-repair.rb

--- a/runbooks/source/incident-log.html.md.erb
+++ b/runbooks/source/incident-log.html.md.erb
@@ -41,9 +41,9 @@ weight: 45
 
 ## Q3 2020 (July - September)
 
-- **Mean Time To Repair**: 59m
+- **Mean Time To Repair**: 1h 9m
 
-- **Mean Time To Resolve**: 7h 22m
+- **Mean Time To Resolve**: 7h 26m
 
 ### Incident on 2020-09-28 13:10 - Termination of nodes updating kops Instance Group.
 
@@ -223,9 +223,9 @@ ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/e
 
 ## Q2 2020 (April - June)
 
-- **Mean Time To Repair**: 2h 49m
+- **Mean Time To Repair**: 2h 5m
 
-- **Mean Time To Resolve**: 7h 12m
+- **Mean Time To Resolve**: 15h 53m
 
 ### Incident on 2020-08-04 17:13
 
@@ -291,9 +291,9 @@ ttps://docs.google.com/document/d/1kxKwC1B_pnlPbysS0zotbXMKyZcUDmDtnGbEyIHGvgQ/e
 
 ## Q1 2020 (January - March)
 
-- **Mean Time To Repair**: 1h 40m
+- **Mean Time To Repair**: 1h 22m
 
-- **Mean Time To Resolve**: 2h 42m
+- **Mean Time To Resolve**: 2h 36m
 
 ### Incident on 2020-02-25 10:58
 

--- a/runbooks/source/mean-time-to-repair.rb
+++ b/runbooks/source/mean-time-to-repair.rb
@@ -14,7 +14,6 @@ QUARTER_REGEX = %r[^## Q\d \d\d\d\d ]
 INCIDENT_REGEX = %r[^### Incident on ]
 TIME_TO_REPAIR_REGEX = %r[- ..Time to repair..: (\d+h \d+m)]
 TIME_TO_RESOLVE_REGEX = %r[- ..Time to resolve..: (\d+h \d+m)]
-TIME_REGEX = %r[(\d\d\d\d-\d\d-\d\d \d\d:\d\d)]
 
 def main
   puts parse_incident_log
@@ -23,6 +22,12 @@ def main
     .map(&:report)
 end
 
+# Turn the incident log into a hash of:
+#
+#   { [quarter label] => [ list of incidents in quarter ], ... }
+#
+# ...where each 'incident' is a hash: { time_to_repair: "Xh Ym", time_to_resolve: "Xh Ym" }
+#
 def parse_incident_log
   data = {}
   current_quarter = nil
@@ -53,13 +58,6 @@ def parse_incident_log
   data[current_quarter].push(current_incident) unless current_incident == {}
   data
 end
-
-def time_from_line(line)
-  if m = TIME_REGEX.match(line)
-    DateTime.parse m[1]
-  end
-end
-
 
 class Quarter
   attr_reader :title, :incidents

--- a/runbooks/source/mean-time-to-repair.rb
+++ b/runbooks/source/mean-time-to-repair.rb
@@ -1,0 +1,122 @@
+#!/usr/bin/env ruby
+
+# Consume the incident log file and output incident performance metrics
+#
+#   Usage: ./mean_time_to_repair.rb
+#
+
+require "date"
+require "pry-byebug"
+
+INCIDENT_LOG = "incident-log.html.md.erb"
+
+QUARTER_REGEX = %r[^## Q\d \d\d\d\d ]
+INCIDENT_REGEX = %r[^### Incident on ]
+TIME_TO_REPAIR_REGEX = %r[- ..Time to repair..: (\d+h \d+m)]
+TIME_TO_RESOLVE_REGEX = %r[- ..Time to resolve..: (\d+h \d+m)]
+TIME_REGEX = %r[(\d\d\d\d-\d\d-\d\d \d\d:\d\d)]
+
+class Quarter
+  attr_reader :title, :incidents
+
+  def initialize(title, incidents)
+    @title = title
+    @incidents = incidents
+      .reject { |i| i == {} }
+      .map { |i| Incident.new(i) }
+  end
+
+  def report
+    <<~EOF
+    #{title}
+      Incidents: #{incidents.length}
+      Mean time to repair: #{mean_time_to_repair}
+      Mean time to resolve: #{mean_time_to_resolve}
+    EOF
+  end
+
+  private
+
+  def mean_time_to_repair
+    sum = incidents.map(&:time_to_repair).sum
+    hours_and_minutes(sum / incidents.length)
+  end
+
+  def mean_time_to_resolve
+    sum = incidents.map(&:time_to_resolve).sum
+    hours_and_minutes(sum / incidents.length)
+  end
+
+  def hours_and_minutes(i)
+    hours = i / 3600
+    seconds = i % 3600
+    minutes = seconds / 60
+    "#{hours}h #{minutes}m"
+  end
+end
+
+class Incident
+  def initialize(params)
+    @time_to_repair = params[:time_to_repair]
+    @time_to_resolve = params[:time_to_resolve]
+  end
+
+  def time_to_repair
+    to_seconds(@time_to_repair || @time_to_resolve) # In case one is missing
+  end
+
+  def time_to_resolve
+    to_seconds(@time_to_resolve || @time_to_repair) # In case one is missing
+  end
+
+  private
+
+  def to_seconds(str)
+    hours, minutes = str.split(" ").map(&:to_i)
+    (hours * 3600) + (minutes * 60)
+  rescue
+    binding.pry
+  end
+end
+
+def parse_incident_log
+  data = {}
+  current_quarter = nil
+  current_incident = nil
+
+  IO.foreach(INCIDENT_LOG) do |l|
+    line = l.chomp
+
+    case line
+    when QUARTER_REGEX
+      if current_quarter
+        data[current_quarter].push(current_incident) unless current_incident.nil?
+      end
+      current_quarter = line
+      data[current_quarter] = []
+    when INCIDENT_REGEX
+      data[current_quarter].push(current_incident) unless current_incident.nil?
+      current_incident = {}
+    when TIME_TO_REPAIR_REGEX
+      m = TIME_TO_REPAIR_REGEX.match(line)
+      current_incident[:time_to_repair] = m[1]
+    when TIME_TO_RESOLVE_REGEX
+      m = TIME_TO_RESOLVE_REGEX.match(line)
+      current_incident[:time_to_resolve] = m[1]
+    end
+  end
+
+  data[current_quarter].push(current_incident) unless current_incident == {}
+  data
+end
+
+def time_from_line(line)
+  if m = TIME_REGEX.match(line)
+    DateTime.parse m[1]
+  end
+end
+
+puts parse_incident_log
+  .map { |quarter, incidents| Quarter.new(quarter, incidents) }
+  .sort { |a, b| a.title <=> b.title }
+  .map(&:report)

--- a/runbooks/source/mean-time-to-repair.rb
+++ b/runbooks/source/mean-time-to-repair.rb
@@ -16,67 +16,11 @@ TIME_TO_REPAIR_REGEX = %r[- ..Time to repair..: (\d+h \d+m)]
 TIME_TO_RESOLVE_REGEX = %r[- ..Time to resolve..: (\d+h \d+m)]
 TIME_REGEX = %r[(\d\d\d\d-\d\d-\d\d \d\d:\d\d)]
 
-class Quarter
-  attr_reader :title, :incidents
-
-  def initialize(title, incidents)
-    @title = title
-    @incidents = incidents
-      .reject { |i| i == {} }
-      .map { |i| Incident.new(i) }
-  end
-
-  def report
-    <<~EOF
-    #{title}
-      Incidents: #{incidents.length}
-      Mean time to repair: #{mean_time_to_repair}
-      Mean time to resolve: #{mean_time_to_resolve}
-    EOF
-  end
-
-  private
-
-  def mean_time_to_repair
-    sum = incidents.map(&:time_to_repair).sum
-    hours_and_minutes(sum / incidents.length)
-  end
-
-  def mean_time_to_resolve
-    sum = incidents.map(&:time_to_resolve).sum
-    hours_and_minutes(sum / incidents.length)
-  end
-
-  def hours_and_minutes(i)
-    hours = i / 3600
-    seconds = i % 3600
-    minutes = seconds / 60
-    "#{hours}h #{minutes}m"
-  end
-end
-
-class Incident
-  def initialize(params)
-    @time_to_repair = params[:time_to_repair]
-    @time_to_resolve = params[:time_to_resolve]
-  end
-
-  def time_to_repair
-    to_seconds(@time_to_repair || @time_to_resolve) # In case one is missing
-  end
-
-  def time_to_resolve
-    to_seconds(@time_to_resolve || @time_to_repair) # In case one is missing
-  end
-
-  private
-
-  def to_seconds(str)
-    hours, minutes = str.split(" ").map(&:to_i)
-    (hours * 3600) + (minutes * 60)
-  rescue
-    binding.pry
-  end
+def main
+  puts parse_incident_log
+    .map { |quarter, incidents| Quarter.new(quarter, incidents) }
+    .sort { |a, b| a.title <=> b.title }
+    .map(&:report)
 end
 
 def parse_incident_log
@@ -116,7 +60,70 @@ def time_from_line(line)
   end
 end
 
-puts parse_incident_log
-  .map { |quarter, incidents| Quarter.new(quarter, incidents) }
-  .sort { |a, b| a.title <=> b.title }
-  .map(&:report)
+
+class Quarter
+  attr_reader :title, :incidents
+
+  def initialize(title, incidents)
+    @title = title
+    @incidents = incidents
+      .reject { |i| i == {} }
+      .map { |i| Incident.new(i) }
+  end
+
+  def report
+    <<~EOF
+    #{title}
+      Incidents: #{incidents.length}
+      Mean time to repair: #{mean_time_to_repair}
+      Mean time to resolve: #{mean_time_to_resolve}
+    EOF
+  end
+
+  private
+
+  def mean_time_to_repair
+    sum = incidents.map(&:time_to_repair).sum
+    hours_and_minutes(sum / incidents.length)
+  end
+
+  def mean_time_to_resolve
+    sum = incidents.map(&:time_to_resolve).sum
+    hours_and_minutes(sum / incidents.length)
+  end
+
+  def hours_and_minutes(i)
+    hours = i / 3600
+    seconds = i % 3600
+    minutes = seconds / 60
+    "#{hours}h #{minutes}m"
+  end
+end
+
+
+class Incident
+  def initialize(params)
+    @time_to_repair = params[:time_to_repair]
+    @time_to_resolve = params[:time_to_resolve]
+  end
+
+  def time_to_repair
+    to_seconds(@time_to_repair || @time_to_resolve) # In case one is missing
+  end
+
+  def time_to_resolve
+    to_seconds(@time_to_resolve || @time_to_repair) # In case one is missing
+  end
+
+  private
+
+  def to_seconds(str)
+    hours, minutes = str.split(" ").map(&:to_i)
+    (hours * 3600) + (minutes * 60)
+  rescue
+    binding.pry
+  end
+end
+
+main
+

--- a/runbooks/source/mean-time-to-repair.rb
+++ b/runbooks/source/mean-time-to-repair.rb
@@ -37,24 +37,32 @@ def parse_incident_log
 
     case line
     when QUARTER_REGEX
-      if current_quarter
+      if current_quarter # i.e. this isn't the first quarter marker in the file
+        # We just reached the next quarter, so add the current incident to the current quarter
         data[current_quarter].push(current_incident) unless current_incident.nil?
       end
+
+      # initialise a new 'quarter' hash
       current_quarter = line
       data[current_quarter] = []
     when INCIDENT_REGEX
+      # We reached an incident marker. Finish off this incident and start a new hash.
       data[current_quarter].push(current_incident) unless current_incident.nil?
       current_incident = {}
     when TIME_TO_REPAIR_REGEX
+      # We've found the time_to_repair line for this incident
       m = TIME_TO_REPAIR_REGEX.match(line)
       current_incident[:time_to_repair] = m[1]
     when TIME_TO_RESOLVE_REGEX
+      # We've found the time_to_resolve line for this incident
       m = TIME_TO_RESOLVE_REGEX.match(line)
       current_incident[:time_to_resolve] = m[1]
     end
   end
 
+  # Ensure we handle the last incident in the file
   data[current_quarter].push(current_incident) unless current_incident == {}
+
   data
 end
 

--- a/runbooks/source/mean-time-to-repair.rb
+++ b/runbooks/source/mean-time-to-repair.rb
@@ -6,7 +6,6 @@
 #
 
 require "date"
-require "pry-byebug"
 
 INCIDENT_LOG = "incident-log.html.md.erb"
 
@@ -115,11 +114,10 @@ class Incident
 
   private
 
+  # "1h 5m" => 3900 (seconds)
   def to_seconds(str)
     hours, minutes = str.split(" ").map(&:to_i)
     (hours * 3600) + (minutes * 60)
-  rescue
-    binding.pry
   end
 end
 

--- a/runbooks/source/mean-time-to-repair.rb
+++ b/runbooks/source/mean-time-to-repair.rb
@@ -90,9 +90,9 @@ class Quarter
     hours_and_minutes(sum / incidents.length)
   end
 
-  def hours_and_minutes(i)
-    hours = i / 3600
-    seconds = i % 3600
+  def hours_and_minutes(seconds)
+    hours = seconds / 3600
+    seconds = seconds % 3600
     minutes = seconds / 60
     "#{hours}h #{minutes}m"
   end


### PR DESCRIPTION
Our incident log has variations from one incident to the next, where
"Incident" is repeated in headings, when it should be "Identified", and
one instance where "Key times" are listed, rather than "Key events".

This PR enforces consistency. This should make it easier for us to use
automated tools to pull out information and statistics about our
incident handling.

This PR also adds a script to output incident performance metrics:

```
$ ./mean-time-to-repair.rb
## Q1 2020 (January - March)
  Incidents: 4
  Mean time to repair: 1h 22m
  Mean time to resolve: 2h 36m
## Q2 2020 (April - June)
  Incidents: 3
  Mean time to repair: 2h 5m
  Mean time to resolve: 15h 53m
## Q3 2020 (July - September)
  Incidents: 7
  Mean time to repair: 1h 9m
  Mean time to resolve: 7h 26m
## Q4 2020 (October - December)
  Incidents: 1
  Mean time to repair: 2h 8m
  Mean time to resolve: 8h 46m
```
