### PR TITLE
Fix build-test-cluster pipeline link

### DIFF
--- a/runbooks/source/create-cluster.html.md.erb
+++ b/runbooks/source/create-cluster.html.md.erb
@@ -191,4 +191,4 @@ https://login.apps.david-test1.cloud-platform.service.justice.gov.uk
 [docker]: https://www.docker.com/
 [PagerDuty]: https://www.pagerduty.com/
 [tools image]: https://github.com/ministryofjustice/cloud-platform-tools-image
-[cluster build pipeline]: https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/build-test-cluster/jobs/build-test-cluster
+[cluster build pipeline]: https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/build-test-cluster/


### PR DESCRIPTION
(because there are eks and kops cluster jobs now)