### PR TITLE
Add disable/enable ingress-clash OPA policy steps

### DIFF
--- a/runbooks/source/zero-downtime-ingress-upgrade.html.md.erb
+++ b/runbooks/source/zero-downtime-ingress-upgrade.html.md.erb
@@ -40,11 +40,22 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx" to <new-ingress-controller-class>
 ```
+
+Disable the `ingress-clash` OPA policy (so that you can create multiple ingresses with the same hostname)
+
+```
+kubectl -n opa delete configmap policy-ingress-clash
+```
+    
 Apply the ingress-second.yaml 
 
 ```
 kubectl -n my-namespace apply -f ingress-second.yaml
 ```
+
+Reinstate the `ingress-clash` OPA policy.
+
+> The easiest way to do this is to `terraform apply` from the `cloud-platform-infrastructure/terraform/cloud-platform-components` directory.
 
 3) In route53 identify the A and txt record, update the txt record with the new ingress name
 


### PR DESCRIPTION
Unless the ingress-clash policy is disabled, it is not possible to create a second ingress with the same hostname, as described in this guide.