### PR TITLE
Remove link to OS Places Runbook

### DIFF
--- a/runbooks/source/os-places-api-key-management.html.md.erb
+++ b/runbooks/source/os-places-api-key-management.html.md.erb
@@ -1,6 +1,4 @@
 ---
-title: OS Places API Key Management
-weight: 9185
 last_reviewed_on: 2020-11-04
 review_in: 3 months
 ---


### PR DESCRIPTION
Removing link to OS Places Runbook. Content migrated to Operations Engineering Runbook site