### PR TITLE
Add "install git-secrets" to onboarding guide

### DIFF
--- a/runbooks/source/joiners-guide.html.md.erb
+++ b/runbooks/source/joiners-guide.html.md.erb
@@ -52,6 +52,14 @@ review_in: 3 months
 ## ACCESS
 
 * Access to AWS accounts this includes MOJ DSD
+* Protect against accidentally pushing secrets to GitHub, using [git-secrets]
+
+```bash
+brew install git-secrets
+git secrets --install ~/.git-templates/git-secrets
+git config --global init.templateDir ~/.git-templates/git-secrets
+```
+
 * Github access - (to be done by new starter)
   * Explain github for RBAC
 * Invite as an admin on [Auth0](https://manage.auth0.com/dashboard/eu/justice-cloud-platform/users)
@@ -66,3 +74,6 @@ review_in: 3 months
 * Add GPG key to git-crypt repositories
   * [environments repo](https://github.com/ministryofjustice/cloud-platform-environments)
   * [infrastructure repo](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/.git-crypt/keys/default/0)
+
+
+[git-secrets]: https://github.com/awslabs/git-secrets


### PR DESCRIPTION
Add a step to install and configure `git-secrets` to help avoid accidentally pushing credentials to github