### PR TITLE
Remove blank line above metadata

### DIFF
--- a/runbooks/source/cloud-platform-to-tgw.html.md.erb
+++ b/runbooks/source/cloud-platform-to-tgw.html.md.erb
@@ -1,4 +1,3 @@
-
 ---
 title: Adding a route to connect to a TGW
 weight: 9000


### PR DESCRIPTION
The runbooks site has been failing to publish since #2607 was merged.

It seems that the blank line at the top of the file causes the middleman build step, which generates the HTML files, to fail.

This change should fix that. I'm going to go ahead and merge this now, because nobody else is around.