### PR TITLE
Update delete-state-lock.html.md.erb

### DIFF
--- a/runbooks/source/delete-state-lock.html.md.erb
+++ b/runbooks/source/delete-state-lock.html.md.erb
@@ -35,8 +35,10 @@ set -euo pipefail
 
 NAMESPACE=$1
 
-for suffix in terraform.tfstate-md5 terraform.tfstate; do
-  json='{"LockID":{"S":"cloud-platform-terraform-state/cloud-platform-environments/live-1.cloud-platform.service.justice.gov.uk/'${NAMESPACE}/${suffix}'"}}'
+PREFIX=cloud-platform-terraform-state/cloud-platform-environments
+
+for key in "${PREFIX}/live-1.cloud-platform.service.justice.gov.uk/${NAMESPACE}/terraform.tfstate-md5" "${PREFIX}/namespaces/live-1.cloud-platform.service.justice.gov.uk/${NAMESPACE}/terraform.tfstate"; do
+  json='{"LockID":{"S":"'${key}'"}}'
 
   aws dynamodb delete-item \
     --region eu-west-1 \


### PR DESCRIPTION
The dynamodb lock keys were incorrect - the `terraform.tfstate` key has `namespaces` in the path.