### PR TITLE
Revert gem dependency bump

### DIFF
--- a/runbooks/Gemfile.lock
+++ b/runbooks/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redcarpet (3.5.1)
+    redcarpet (3.5.0)
     rouge (3.20.0)
     ruby-enum (0.8.0)
       i18n


### PR DESCRIPTION
This change reverts #2653 because the Gemfile.lock in this repo needs to exactly match the one in the publisher docker image.