### PR TITLE
Add some clarifications around on-call approval for managers

### DIFF
--- a/runbooks/source/on-call.html.md.erb
+++ b/runbooks/source/on-call.html.md.erb
@@ -50,8 +50,9 @@ Civil servant equivalent of day rate is base salary / 230
 
 The line manager should:
 
+_Note that there are two on-call schedules for the Cloud Platform (Primary and Secondary), so when checking against PagerDuty, you may have to check against both._
+
 1. Check the form against the PagerDuty schedule and pay policy above
-  * Line items may appear in either "Primary" or "Secondary" schedules and should be a split out on the claim form
 2. Approve the form by completing section 3 of the form
 3. Submit it in SOP:
   * Go to "MOJ Manager Self-Service"

--- a/runbooks/source/on-call.html.md.erb
+++ b/runbooks/source/on-call.html.md.erb
@@ -50,19 +50,21 @@ Civil servant equivalent of day rate is base salary / 230
 
 The line manager should:
 
-1. Check the form against the Pagerduty schedule and pay policy above.
-2. Approve the form by completing section 3 of the form.
+1. Check the form against the PagerDuty schedule and pay policy above
+  * Line items may appear in either "Primary" or "Secondary" schedules and should be a split out on the claim form
+2. Approve the form by completing section 3 of the form
 3. Submit it in SOP:
-    * MOJ Manager Self-Service | Form Submission
-    * Against the employee's name, select "Action"
-    * Web form:
-        * Subject of this request: Other
-        * Describe the subject: On call allowance
-        * Confirm: Yes
-    * Form Submission Review:
-        * Attach spreadsheet
-    * "Submit"
-    * In around 15 minutes you'll receive a SOP notification "SOP Service Request for X has been approved", which you will need to open and select 'Ok'. Otherwise you will get daily reminder emails.
+  * Go to "MOJ Manager Self-Service"
+  * Under "Other", use "Form Submission"
+  * Against the employee's name, select "Action"
+  * Fill out the web form as follows:
+      * Subject of this request: Other
+      * Describe the subject: On call allowance
+      * Confirm: Yes
+  * Form Submission Review:
+      * Attach the approved spreadsheet
+  * "Submit"
+  * In around 15 minutes you'll receive a SOP notification "SOP Service Request for X has been approved", which you will need to open and select 'Ok'. Otherwise you will get daily reminder emails.
 4. Let the claimant know that it is submitted to SOP, so it's due to be paid in this or next month's pay.
 
 ## Contractors


### PR DESCRIPTION
This PR adds a couple of clarifications around how to approve on-call forms:

- what heading the Form Submission action is under
- line items in an form may be from different schedules in PagerDuty ("primary" and "secondary")

