### PR TITLE
Bump image version 1.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/cloud-platform-tech-docs-publisher:1.0
+      image: ministryofjustice/cloud-platform-tech-docs-publisher:1.3
     steps:
     - uses: actions/checkout@v2
     - name: Build

--- a/runbooks/makefile
+++ b/runbooks/makefile
@@ -1,4 +1,4 @@
-PUBLISHING_IMAGE := ministryofjustice/cloud-platform-tech-docs-publisher:1.1
+PUBLISHING_IMAGE := ministryofjustice/cloud-platform-tech-docs-publisher:1.3
 
 # Use this to run a local instance of the documentation site, while editing
 .PHONY: preview


### PR DESCRIPTION
The Gemfile.lock had a bundle update for nokogiri and mini_portile2 and new release made.
The cloud-platform-tech-docs-publisher image build process is managed in https://github.com/ministryofjustice/cloud-platform-user-guide