### PR TITLE
EKS ADR - add details of the prometheus node group

### DIFF
--- a/architecture-decision-record/022-EKS.md
+++ b/architecture-decision-record/022-EKS.md
@@ -23,7 +23,7 @@ We've gained a lot experience of using EKS with the Manager cluster
 
 ### Auth
 
-**Chosen:**: OIDC, with Auth0 as broker and GitHub as Identity Provider
+**Chosen:** OIDC, with Auth0 as broker and GitHub as Identity Provider
 
 Developers in service teams need to use the k8s auth, and GitHub continues to be the most common SSO amongst them with good tie-in to JML processes - see [ADR 6 Use GitHub as our identity provider](006-Use-github-as-user-directory.md)
 
@@ -36,7 +36,7 @@ Future options:
 
 ### Auth credential issuer
 
-**Chosen:**: Cloud Platform Kuberos
+**Chosen:** Cloud Platform Kuberos
 
 We've long used Kuberos for issuing kubecfg credentials to users. The [original version of Kuberos](https://github.com/negz/kuberos) is unmaintained, but it's pretty simple, so we have updated the dependencies in: https://github.com/ministryofjustice/cloud-platform-kuberos/ and will maintain our fork.
 
@@ -51,13 +51,13 @@ Other options considered:
 
 ### Authorization
 
-**Chosen:**: existing RBAC configuration
+**Chosen:** existing RBAC configuration
 
 We'll continue to use our existing RBAC configuration from the previous cluster.
 
 ### Node management
 
-**Chosen:**: Managed node groups, with future experimenting with Fargate
+**Chosen:** Managed node groups, with future experimenting with Fargate
 
 Options:
 
@@ -106,11 +106,11 @@ These EKS AMIs are the default and therefore lowest maintenance. We can't see a 
 
 ### Node groups
 
-**Chosen:** One node group initially, with a couple of instance types
+**Chosen:** A main node group for majority workloads, and a prometheus node group.
 
-Start with one node group, to minimize the operation overhead.
+We'll minimize the number of node groups, to minimize the operation overhead.
 
-In the node group we will specify 2 or 3 related instance types, because with only 1 there is a risk that the cloud provider runs out of that type within the region.
+For Prometheus, we continue our design from our previous cluster, where we have a separate node group of larger nodes, dedicated to Prometheus pods. This is because Prometheus is resource hungry for memory and disk IOPS. We will have two large nodes, in a single availability zone, so they can both access the EBS volume that stores metrics data.
 
 Further node groups may be valueable for using Spot or Fargate nodes, as we explore them in the future.
 


### PR DESCRIPTION
I missed this prometheus node group from this doc. Today we agreed that we need it, so added it here.