### PR TITLE
Update provisioning EKS clusters runbook

### DIFF
--- a/runbooks/source/delete-cluster.html.md.erb
+++ b/runbooks/source/delete-cluster.html.md.erb
@@ -102,7 +102,7 @@ kops has set your kubectl context to david-test1.cloud-platform.service.justice.
 Then, from the components directory, run these commands to destroy all cluster components, and delete the terraform workspace.
 
 ```
-$ cd terraform/cloud-platform-components
+$ cd terraform/aws-accounts/cloud-platform-aws/vpc/kops/components
 $ terraform init
 $ terraform workspace select <clusterName e.g. cloud-platform-test-3>
 $ terraform destroy -target helm_release.prometheus_operator # delete first, to avoid conflicts later
@@ -122,7 +122,7 @@ $ kops delete cluster --name <clusterName>.cloud-platform.service.justice.gov.uk
 Change directories and perform the following to destroy the cluster essentials, and delete the terraform workspace.
 
 ```
-$ cd ../cloud-platform
+$ cd .. # working dir is now `kops`
 $ terraform init
 $ terraform workspace select <clusterName e.g. cloud-platform-test-3>
 $ terraform destroy
@@ -133,7 +133,7 @@ $ terraform workspace delete <clusterName>
 Change directories and perform the following to destroy the cluster VPC, and delete the terraform workspace.
 
 ```
-$ cd ../cloud-platform-network
+$ cd .. # working dir is now `vpc`
 $ terraform init
 $ terraform workspace select <clusterName e.g. cloud-platform-test-3>
 $ terraform destroy
@@ -153,4 +153,4 @@ The steps can be found here - [Delete an EKS Cluster]
 [bootstrap pipleine]: https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/bootstrap
 [create-test-destroy]: https://github.com/ministryofjustice/cloud-platform-concourse/blob/main/pipelines/manager/main/create-test-destroy.yaml
 [cluster-name-export]: https://github.com/ministryofjustice/cloud-platform-concourse/blob/main/pipelines/manager/main/create-test-destroy.yaml#L140
-[Delete an EKS Cluster]: eks-tools-cluster.html#4-delete-the-eks-cluster
+[Delete an EKS Cluster]: eks-cluster.html#4-delete-the-eks-cluster

--- a/runbooks/source/eks-cluster.html.md.erb
+++ b/runbooks/source/eks-cluster.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: EKS Tool/Manager Cluster
+title: EKS Cluster
 weight: 350
 last_reviewed_on: 2021-04-20
 review_in: 3 months
@@ -7,11 +7,13 @@ review_in: 3 months
 
 # Provisioning EKS clusters
 
-For the time being EKS is only used for the manager cluster, it mainly holds Cloud Platform concourse CI.
+For now EKS is only used for the manager cluster, it mainly holds Cloud Platform concourse CI. We are working on migrating our live cluster to EKS. 
 
 **IMPORTANT:** All cluster's names **must be globally unique** (EKS or kOps). Each one creates a unique Route53 hostzone which is unique to the name
 
-You can create a new EKS test cluster using the `create-cluster` script.
+You can create a new EKS test cluster using the [cluster build pipeline].
+
+Alternatively, using the `create-cluster` script.
 
 Execute the script, by giving the `-k eks` or `--kind eks` option and the desired name of your new cluster. e.g.:
 
@@ -37,10 +39,10 @@ Alternatively, if you need more control over the test cluster parameters, or you
 
 ### 1. VPC
 
-We need to create a VPC to deploy the cluster, VPCs are deployed using terraform code under [cloud-platform-infrastructure/terraform/cloud-platform-network](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/cloud-platform-network) folder:
+We need to create a VPC to deploy the cluster, VPCs are deployed using terraform code under [cloud-platform-infrastructure/terraform/aws-accounts/cloud-platform-aws/vpc](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/aws-accounts/cloud-platform-aws/vpc) folder:
 
 ```
-cd cloud-platform-infrastructure/terraform/cloud-platform-network
+cd cloud-platform-infrastructure/terraform/aws-acounts/cloud-platform-aws/vpc
 terraform init
 terraform workspace new <WorkspaceName>
 terraform apply
@@ -93,6 +95,40 @@ terraform apply
 
 ### 4. Delete the EKS cluster
 
+#### Delete the EKS cluster using the script
+
+There is a [destroy-cluster.rb] script which you can use to delete your cluster.
+
+Read the script before using it. Deleting a cluster is something you should be very cautious about, and ensure you know exactly what you're doing.
+
+The script is entirely non-interactive, and will not prompt you to confirm anything. It just destroys things.
+
+First, run `make tools-shell`
+
+> The delete cluster script must *always* be run in a container. This ensures that the environment of the script is fully controlled, and you don't run into problems such as the kubernetes context being changed in another window, or extra environment variables causing unwanted effects.
+
+Then invoke the script like this:
+
+```
+./destroy-cluster.rb --name [short cluster name] --kind eks --yes
+```
+
+Run without `--yes` to do a dry run, and see what commands would be executed.
+
+You can get more information using:
+
+```
+./destroy-cluster.rb --help
+```
+
+If any steps fail:
+
+* Fix the underlying problem
+* Edit the script to comment out any sections of the `ClusterDeleter.run` function which you no longer need to run
+* Re-run the script
+
+#### Delete the EKS cluster manually
+
 Follow these steps, to delete the EKS cluster.
 
 First, set the kubectl context for the EKS cluster you are deleting. The easiest way to do this is with aws command:
@@ -132,7 +168,7 @@ $ terraform workspace delete ${cluster}
 Change directories and perform the following to destroy the EKS cluster, and delete the terraform workspace.
 
 ```
-$ cd .. # working dir is now `cloud-platform-eks`
+$ cd .. # working dir is now `eks`
 $ terraform init
 $ terraform workspace select ${cluster}
 $ terraform destroy
@@ -140,4 +176,17 @@ $ terraform workspace select default
 $ terraform workspace delete ${cluster}
 ```
 
-[create a cluster](https://runbooks.cloud-platform.service.justice.gov.uk/create-cluster.html#create-a-new-cluster)
+Change directories and perform the following to destroy the cluster VPC, and delete the terraform workspace.
+
+```
+$ cd .. # working dir is now `vpc`
+$ terraform init
+$ terraform workspace select ${cluster}
+$ terraform destroy
+$ terraform workspace select default
+$ terraform workspace delete ${cluster}
+```
+
+[create a cluster]: https://runbooks.cloud-platform.service.justice.gov.uk/create-cluster.html#create-a-new-cluster
+[cluster build pipeline]: https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/build-test-cluster/
+[destroy-cluster.rb]: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/destroy-cluster.rb


### PR DESCRIPTION
This is to rename the runbook by removing the Tool/Manager name in it, as we are planning to move to EKS, and not just have an EKS cluster for managing.

Add information related to destroying the EKS cluster using the script, updated the runbook to reflect the new folder structure.