### PR TITLE
Link to the on-call hours

### DIFF
--- a/runbooks/source/on-call.html.md.erb
+++ b/runbooks/source/on-call.html.md.erb
@@ -7,6 +7,8 @@ review_in: 3 months
 
 # Going on call
 
+Cloud Platform team members provide support out of hours, as detailed in [Cloud Platform Operational Processes](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/reference/operational-processes.html#our-on-call-process)
+
 ## What’s expected?
 
 ### Expected:
@@ -28,10 +30,10 @@ review_in: 3 months
 1. Do two rotations on in-hours second line.
 2. Get production access to supported services.
 3. Get access to our on-call tools:
-  * [Pingdom](https://my.pingdom.com/)
-  * [Pagerduty](https://moj-digital-tools.pagerduty.com/) (and configure your contact details and notifications, this is the single source of truth for when you are on call.)
-  * [AWS](https://mojdsd.signin.aws.amazon.com/)
-  * the MOJDS VPN (and configure it to “send all traffic over VPN connection”)
+    * [Pingdom](https://my.pingdom.com/)
+    * [Pagerduty](https://moj-digital-tools.pagerduty.com/) (and configure your contact details and notifications, this is the single source of truth for when you are on call.)
+    * [AWS](https://mojdsd.signin.aws.amazon.com/)
+    * the MOJDS VPN (and configure it to “send all traffic over VPN connection”)
 4. Do a dry-run of an incident.
 5. Get on the on-call rota.
 6. Log your hours.
@@ -50,22 +52,22 @@ Civil servant equivalent of day rate is base salary / 230
 
 The line manager should:
 
-_Note that there are two on-call schedules for the Cloud Platform (Primary and Secondary), so when checking against PagerDuty, you may have to check against both._
-
-1. Check the form against the PagerDuty schedule and pay policy above
+1. Check the form against the [PagerDuty schedule](https://moj-digital-tools.pagerduty.com/schedules#PFX6FHX) and pay policy above. Note:
+    * _There are two on-call schedules for the Cloud Platform (Primary and Secondary), so when checking against PagerDuty, you may have to check against both_
+    * On-call hours: weekdays are 8 hours, weekend days and bank holidays are 15 hours ([support hours](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/reference/operational-processes.html#our-on-call-process))
 2. Approve the form by completing section 3 of the form
 3. Submit it in SOP:
-  * Go to "MOJ Manager Self-Service"
-  * Under "Other", use "Form Submission"
-  * Against the employee's name, select "Action"
-  * Fill out the web form as follows:
-      * Subject of this request: Other
-      * Describe the subject: On call allowance
-      * Confirm: Yes
-  * Form Submission Review:
-      * Attach the approved spreadsheet
-  * "Submit"
-  * In around 15 minutes you'll receive a SOP notification "SOP Service Request for X has been approved", which you will need to open and select 'Ok'. Otherwise you will get daily reminder emails.
+    * Go to "MOJ Manager Self-Service"
+    * Under "Other", use "Form Submission"
+    * Against the employee's name, select "Action"
+    * Fill out the web form as follows:
+        * Subject of this request: Other
+        * Describe the subject: On call allowance
+        * Confirm: Yes
+    * Form Submission Review:
+        * Attach the approved spreadsheet
+    * "Submit"
+    * In around 15 minutes you'll receive a SOP notification "SOP Service Request for X has been approved", which you will need to open and select 'Ok'. Otherwise you will get daily reminder emails.
 4. Let the claimant know that it is submitted to SOP, so it's due to be paid in this or next month's pay.
 
 ## Contractors


### PR DESCRIPTION
Knowing the hours is helpful for understanding the job and the claim form.

Also indent of bullets to be more indented than the number sections they are within. Some markdown renderers are fussy about this, although this one is not, and markdown linter highlights this in my editor...