### PR TITLE
Bump tech-docs image to 1.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/cloud-platform-tech-docs-publisher:1.3
+      image: ministryofjustice/cloud-platform-tech-docs-publisher:1.5
     steps:
     - uses: actions/checkout@v2
     - name: Build


### PR DESCRIPTION
The Gemfile.lock in the tech-docs image has been updated and a new release was made. https://github.com/ministryofjustice/cloud-platform-user-guide/releases/tag/1.5. Bump the image tag to use the latest