### PR TITLE
Add link checker to create issues on broken links

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -1,0 +1,27 @@
+name: Links
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 18 * * *"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.0.9
+        with:
+          args: --verbose --no-progress **/*.md **/*.html **/*.erb
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Create Issue From File
+        uses: peter-evans/create-issue-from-file@v3
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: documentation


### PR DESCRIPTION
---
name: Cloud Platform Pull Request
about: Create new pull request for this repository

---

## Purpose

Adds a link checker GH Action to check all links in our documentation and creates an issue in the repository.

## Approach

One of the main reasons to check our docs is to weed out any broken links. This saves me having to click through each link when reviewing the document.

## Ticket

No ticket.

Tickets can be also referenced using "Connects to #NN" and "Closes #NN" syntax.
Please see Reference section for more information.

## Reference

[How to write good pull requests](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
[Waffle - "connects to" usage](https://help.waffle.io/faq/waffle-workflow/use-waffles-connect-keyword-to-connect-prs-to-issues)
[Github - closing issues with keywords](https://help.github.com/articles/closing-issues-using-keywords/)
