### PR TITLE
Pod density info added to ADR

### DIFF
--- a/architecture-decision-record/022-EKS.md
+++ b/architecture-decision-record/022-EKS.md
@@ -111,13 +111,13 @@ Further node groups may be valueable for using Spot or Fargate nodes, as we expl
 
 ### Node instance types
 
-**Chosen:** r5.xlarge, r4.xlarge, r5.4xlarge - for the main node group
+**Chosen:** r5.xlarge, r5.4xlarge - for the main node group
 
 **Chosen:** IP Prefixes [configured](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-prefix-eni.html) in the image
 
 In choosing instance types, our past experience has been that memory tends to be the limiting factor, so we have gone for the memory optimized range of instance types - 'r'. r5 is the latest, and most cost efficient, in that range, without going for ARM processors (see consideration below). This is what we use on the current cluster, so we'll stick with that for now.
 
-Due to the choice of AWS CNI networking in the new cluster, we were concerned about a new limit on pods per node, due to limitations on ENIs / IP addresses. However AWS has now released [IP prefixes](https://aws.amazon.com/about-aws/whats-new/2021/07/amazon-virtual-private-cloud-vpc-customers-can-assign-ip-prefixes-ec2-instances/), which enables us to avoid this limit.
+The choice of AWS CNI networking in the new cluster, initially added a constraint on the number of pods per node, due to limitations on numbers of ENIs / IP addresses. However AWS has now released [IP prefixes](https://aws.amazon.com/about-aws/whats-new/2021/07/amazon-virtual-private-cloud-vpc-customers-can-assign-ip-prefixes-ec2-instances/), giving higher pod density per node, which enables us to avoid this limit. Support is added in [AWS CNI 1.9.0](https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.9.0) and it requires instances to be "nitro"-based, which the r5 range is, but not r4.
 
 So the primary choice is:
 
@@ -125,7 +125,6 @@ So the primary choice is:
 
 With fallbacks (should the cloud provider run out of these in the AZ):
 
-* r4.xlarge - 4 vCPUs, 30.5GB memory
 * r5.4xlarge - 64 vCPUs, 128GB memory
 
 In the future we might consider the ARM processor ranges, but we'd need to consider the added complexity of cross-compiled container images.


### PR DESCRIPTION
Following research by @vijay-veeranki in:
https://docs.google.com/document/d/1dNdDFXWhRcgtoMcZyZl0oNXz5MxU3slvZXmicouk3Fg/edit

Note to @vijay-veeranki we won't be able to use r4 as a fallback any more in the main node group