### PR TITLE
ADR EKS Fallback to r5.2xlarge

### DIFF
--- a/architecture-decision-record/022-EKS.md
+++ b/architecture-decision-record/022-EKS.md
@@ -125,7 +125,7 @@ So the primary choice is:
 
 With fallbacks (should the cloud provider run out of these in the AZ):
 
-* r5.4xlarge - 64 vCPUs, 128GB memory
+* r5.2xlarge - 8 vCPUs, 64GB memory
 * r5a.xlarge - 4 vCPUs, 32GB memory
 
 In the future we might consider the ARM processor ranges, but we'd need to consider the added complexity of cross-compiled container images.


### PR DESCRIPTION
Now taking account of the 110 pod per node limit that k8s imposes by default,
r5.2xlarge is significantly better than r5.4xlarge as a fallback.

Sheet updated too:
https://docs.google.com/spreadsheets/d/1JpZudxmGkP-JNpOs36hipFPbWGCCkaCmi9pP_Rc9yng/edit#gid=383355774