### PR TITLE
zenhub.com does not like a link-check, so ignore the false 404

### DIFF
--- a/.ignore-links
+++ b/.ignore-links
@@ -19,3 +19,4 @@ https://etcd-x.internal/
 https://concourse.apps.david-test1.cloud-platform.service.justice.gov.uk/
 http://localhost:9090
 https://sonarqube.thistheurl.com/
+https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/board


### PR DESCRIPTION
Fixes #3364