### PR TITLE
FIX: Typo in runbook

### DIFF
--- a/runbooks/source/create-cluster.html.md.erb
+++ b/runbooks/source/create-cluster.html.md.erb
@@ -190,13 +190,13 @@ If you want to authenticate to your new cluster in the same way as a regular use
 in via auth0, rather than using `kops export kubecfg...`), the auth0 login URL is:
 
 ```
-https://login.apps.[cluster name].cloud-platform.service.justice.gov.uk
+https://login.[cluster name].cloud-platform.service.justice.gov.uk
 ```
 
 e.g. for a cluster called "david-test1", the URL to authenticate and download a `~/.kube/config` file is:
 
 ```
-https://login.apps.david-test1.cloud-platform.service.justice.gov.uk
+https://login.david-test1.cloud-platform.service.justice.gov.uk
 ```
 
 [infrastructure repo]: https://github.com/ministryofjustice/cloud-platform-infrastructure


### PR DESCRIPTION
the auth0 url within the authernticating section has a typo. Updating
this url to the correct address by removing the apps from this url