### PR TITLE
Update Switch-ingress-to-v1-ingress-controller

### DIFF
--- a/runbooks/source/Switch-ingress-to-v1-ingress-controller.html.md.erb
+++ b/runbooks/source/Switch-ingress-to-v1-ingress-controller.html.md.erb
@@ -94,7 +94,7 @@ metadata:
   name: helloworld
   annotations:
     kubernetes.io/ingress.class: nginx
-    external-dns.alpha.kubernetes.io/set-identifier: helloworld-new-mynamespace-green
+    external-dns.alpha.kubernetes.io/set-identifier: helloworld-mynamespace-green
     <b>external-dns.alpha.kubernetes.io/aws-weight: "0"</b>
 spec:
   tls:


### PR DESCRIPTION
The `new` tag has been left on the current, zero weighted, example

Question - is having the current ingress labelled as `servicename-green` and the new version `servicename-new-green` okay, or should we be using the blue/green split we did when transitioning the clusters?

Maybe adding a comment to explain either way would be good, as it was the first thing that confused me! 😄 