### PR TITLE
Add troubleshoot for EKS cluster upgrade

### DIFF
--- a/runbooks/source/upgrade-eks-cluster.html.md.erb
+++ b/runbooks/source/upgrade-eks-cluster.html.md.erb
@@ -112,6 +112,31 @@ We have 3 addons managed through cloud-platform-terraform-eks-add-ons [module](h
 
 Refer to the below documents to get the addon version to be used with the EKS major version you just upgraded to.
 
+### Troubleshooting
+
+When we update node group version or change launch template version, we had error "Reached max retries while trying to evict pods from nodes in node group live-default_ng_xxxx", even using force which does not respect pod disruption budgets and it forces node restarts. The force drain mode can fail to evict pods when there are pods in CrashLoopBack state and PDB is in effect, related to this [issue](https://github.com/kubernetes/kubernetes/issues/72320) 
+
+We can use cloudwatch logs insights with following filter to understand for which all pods the eviction was a failure.
+
+  1) Go to cloudwatch logs console, then click on insights.
+  2) Now in the current window, select log groups which corresponds to Cluster Control Plane logs. For live cluster it is: "/aws/eks/live/cluster"
+  3) Use the below filter to check on all eviction failures that happened to the EKS cluster
+
+  ```
+  fields @timestamp, @message | filter @logStream like "kube-apiserver-audit" | filter ispresent(requestURI) | filter objectRef.subresource = "eviction" | filter responseObject.status = "Failure"
+  ```
+
+  4) After running the query with above filter, you could see all the eviction failures which includes repeated retries performed by the client.
+  5) The "requestURI" present inside the message in the results of above query will point you on which pods triggered eviction failure.
+  6) Further to filter out all such duplicate eviction retries you could use the following query.
+
+  ```
+  fields @timestamp, @message | filter @logStream like "kube-apiserver-audit" | filter ispresent(requestURI) | filter objectRef.subresource = "eviction" | filter responseObject.status = "Failure" | display @logStream, requestURI, responseObject.message | stats count(*) as retry by requestURI, requestObject.message
+  ```
+
+Delete the eviction failure pods manually to avoid the error "Reached max retries while trying to evict pods from nodes in node group live-default_ng_xxxx"
+
+
 [managing-kube-proxy](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html)
 
 [managing-coredns](https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html)


### PR DESCRIPTION
This is related to an error we see while updating/upgrading node group
error "Reached max retries while trying to evict pods from nodes in node group live-default_ng_xxxx"