### PR TITLE
docs: Adding new runbook for k8 deprecated versions

### DIFF
--- a/runbooks/source/finding-deprecated-versions-for-k8-upgrade.html.md.erb
+++ b/runbooks/source/finding-deprecated-versions-for-k8-upgrade.html.md.erb
@@ -1,0 +1,24 @@
+---
+title: Finding deprecated versions for kubernetes upgrade
+weight: 8989
+last_reviewed_on: 2022-07-18
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+  
+### What is deprecated?
+  
+Kubernetes is a large system with many components and many contributors. As with any such software, the feature set naturally evolves over time, and sometimes a feature may need to be removed. This could include an API, a flag, or even an entire feature. To avoid breaking existing users, Kubernetes follows a deprecation policy for aspects of the system that are slated to be removed.
+
+### Using kubent to find deprecated versions within a cluster for upgrading 
+
+Repository: [kubent](https://github.com/doitintl/kube-no-trouble)
+
+Kubent is a tool that will run against a cluster and create a list showing deprecated components and the namespace they belong to,  that are currently in the cluster and the versions needed to replace them to upgrade the kubernetes version.
+
+The tool is simple to use, follow the [README](https://github.com/doitintl/kube-no-trouble/blob/master/README.md) in the repository linked above
+
+
+  


### PR DESCRIPTION
Runbook details a tool called kubent that helps identify deprecated versions within a cluster that will have to be upgraded before moving to a newer kubernetes version