### PR TITLE
Add runbook to manage grafana snapshot

### DIFF
--- a/runbooks/source/manage-grafana-snapshots.html.md.erb
+++ b/runbooks/source/manage-grafana-snapshots.html.md.erb
@@ -1,0 +1,63 @@
+---
+title: Manage Published Grafana Dashboard Snapshots
+weight: 190
+last_reviewed_on: 2022-07-25
+review_in: 3 months
+---
+
+# Manage Published Grafana Dashboard Snapshots
+
+Users are able to Publish Grafana Dashboard Snapshots which are available publicly. There are various Expire options available including `Never` expire. 
+If a user chooses this option, but later requires to remove the snapshot from public view, the Cloud Platform team are required to remove this. This is due to all users having read access only to Grafana.
+
+## Steps to remove Snapshot
+
+1) Retrieve the admin username and password for Grafana. This is stored in the `prometheus-operator-grafana` secret within the `Monitoring` namespace.
+    
+    You can use the cloud-platform-cli to retrieve this:
+
+    ```
+    cloud-platform decode-secret -n monitoring -s prometheus-operator-grafana
+    ```
+
+2) Using the admin credentials and the Grafana API, run the following `curl` command to get a list of all the published snapshots:
+
+    ```
+    curl 'https://<admin-id>:<admin_pass>@grafana.live.cloud-platform.service.justice.gov.uk/api/dashboard/snapshots'
+    ```
+
+    Example:
+
+    ```
+    curl 'https://abc123:abc123@grafana.live.cloud-platform.service.justice.gov.uk/api/dashboard/snapshots'
+
+    ```
+
+    The output should look something like the below:
+
+    ```
+    [{"id":1,"name":"my_dashboard","key":"abcdefg123456","orgId":123,"userId":123,"external":false,"externalUrl":"","expires":"2072-07-08T15:19:01Z","created":"2022-07-21T15:19:01Z","updated":"2022-07-21T15:19:01Z"}]
+    [{"id":2,"name":"your_dashboard","key":"98765qwerty","orgId":123,"userId":123,"external":false,"externalUrl":"","expires":"2072-07-08T15:19:01Z","created":"2022-07-21T15:19:01Z","updated":"2022-07-21T15:19:01Z"}]
+
+    ```
+
+3) Retrieve the `"key":` value of the dashboard you would like to remove.
+
+4) Run the following `curl` command to delete the snapshot:
+
+    ```
+    curl -X DELETE 'https://<admin-id>:<admin_pass>@grafana.live.cloud-platform.service.justice.gov.uk/api/snapshots/<snapshot_key>'
+
+    ```
+    Example:
+
+    ```
+    curl -X DELETE 'https://abc123:abc123@grafana.live.cloud-platform.service.justice.gov.uk/api/snapshots/abcdefg123456'
+    ```
+
+    The output should look something like the below:
+
+    ```
+    {"id":1,"message":"Snapshot deleted. It might take an hour before it's cleared from any CDN caches."}
+
+    ```


### PR DESCRIPTION
Runbook with steps to remove Grafana Dashboard Snapshots which have been set to never expire from being publicly available, when users require it. 