### PR TITLE
Add script to quickly review documents

### DIFF
--- a/document.go
+++ b/document.go
@@ -39,22 +39,20 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	if fix {
-		for _, doc := range docs {
-			err := setLastReviewedOn(doc)
-			if err != nil {
-				log.Fatalln(err)
-			}
+	for _, doc := range docs {
+		needsReview, err := needsReview(doc, threeMonthsAgo)
+		if err != nil {
+			log.Printf("Unable to check if document: %s needs review %s\n", doc, err)
 		}
-	} else {
-		for _, doc := range docs {
-			needsReview, err := needsReview(doc, threeMonthsAgo)
-			if err != nil {
-				log.Printf("Unable to check if document: %s needs review %s\n", doc, err)
+		if needsReview {
+			if fix {
+				err := setLastReviewedOn(doc)
+				if err != nil {
+					log.Println(err)
+				}
+				continue
 			}
-			if needsReview {
-				fmt.Println(doc)
-			}
+			fmt.Println(doc)
 		}
 	}
 }

--- a/document.go
+++ b/document.go
@@ -22,12 +22,10 @@ import (
 
 func main() {
 	var (
-		dir  string
-		repo string
-		fix  bool
+		dir string
+		fix bool
 	)
 	flag.StringVar(&dir, "dir", ".", "The directory to search for documents")
-	flag.StringVar(&repo, "repo", "cloud-platform", "The root repository to search for documents")
 	flag.BoolVar(&fix, "fix", false, "Set the out of date documents to todays date")
 	flag.Parse()
 
@@ -58,8 +56,6 @@ func main() {
 }
 
 func setLastReviewedOn(filePath string) error {
-	// Set the last_reviewed_on date to today.
-	// read the whole file at once
 	b, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return err
@@ -88,8 +84,6 @@ func parseTime(timeString string) (time.Time, error) {
 }
 
 func needsReview(filePath, threeMonthsAgo string) (bool, error) {
-	// Date three months ago.
-	// Grab the last_reviewed_on date from the document.
 	lastReviewedOn, err := lastReviewedOn(filePath)
 	if err != nil {
 		return false, errors.Wrap(err, "unable to get last_reviewed_on")
@@ -141,7 +135,6 @@ func contains(slice []string, item string) bool {
 }
 
 func allDocuments(dir string) ([]string, error) {
-	// documents is a map of document names and dates to review them by.
 	ignored := []string{
 		"incident-log.html.md.erb",
 		"index.html.md.erb",

--- a/document.go
+++ b/document.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func main() {
+	var (
+		dir string
+		fix bool
+	)
+	flag.StringVar(&dir, "dir", "runbooks/source", "The directory to search for documents")
+	flag.BoolVar(&fix, "fix", false, "Set the out of date documents to todays date")
+	flag.Parse()
+
+	threeMonthsAgo := time.Now().AddDate(0, -3, 0).Format("2006-01-02")
+
+	err := checkWorkingDir(dir)
+	if err != nil {
+		// Hard error if the user executes from the wrong directory.
+		log.Fatalln(err)
+	}
+
+	// Grab all documents needed to review.
+	docs, err := allDocuments(dir)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	if fix {
+		for _, doc := range docs {
+			err := setLastReviewedOn(doc)
+			if err != nil {
+				log.Fatalln(err)
+			}
+		}
+	} else {
+		for _, doc := range docs {
+			needsReview, err := needsReview(doc, threeMonthsAgo)
+			if err != nil {
+				log.Printf("Unable to check if document: %s needs review %s\n", doc, err)
+			}
+			if needsReview {
+				fmt.Println(doc)
+			}
+		}
+	}
+}
+
+func setLastReviewedOn(filePath string) error {
+	// Set the last_reviewed_on date to today.
+	// read the whole file at once
+	b, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	lastReviewedOn, err := lastReviewedOn(filePath)
+	if err != nil {
+		return errors.Wrap(err, "unable to get last_reviewed_on")
+	}
+
+	o := bytes.Replace(b, []byte(lastReviewedOn), []byte(time.Now().Format("2006-01-02")), 1)
+	err = ioutil.WriteFile(filePath, o, 0644)
+	if err != nil {
+		return errors.Wrap(err, "unable to write file")
+	}
+
+	return nil
+}
+
+func checkWorkingDir(workingDir string) error {
+	// Am I in the `cloud-platform` directory?
+	const expectedDir = "cloud-platform"
+	repo, err := findTopLevelGitDir("./")
+	if err != nil {
+		return fmt.Errorf("unable to get the repository name, %e", err)
+	}
+
+	if !strings.Contains(repo, expectedDir) {
+		return fmt.Errorf("you must execute in the %s repoa, %e", expectedDir, err)
+	}
+	return nil
+}
+
+func parseTime(timeString string) (time.Time, error) {
+	format := "2006-01-02"
+	return time.Parse(format, strings.TrimSpace(timeString))
+}
+
+func needsReview(filePath, threeMonthsAgo string) (bool, error) {
+	// Date three months ago.
+	// Grab the last_reviewed_on date from the document.
+	lastReviewedOn, err := lastReviewedOn(filePath)
+	if err != nil {
+		return false, errors.Wrap(err, "unable to get last_reviewed_on")
+	}
+	// Compare the last_reviewed_on date to the threeMonthsAgo date.
+	lastReviewedOnTime, err := parseTime(lastReviewedOn)
+	if err != nil {
+		return false, fmt.Errorf("unable to parse last_reviewed_on: %s, %w", lastReviewedOn, err)
+	}
+	threeMonthsAgoTime, err := parseTime(threeMonthsAgo)
+	if err != nil {
+		return false, fmt.Errorf("unable to parse time: %s", threeMonthsAgo)
+	}
+
+	if lastReviewedOnTime.Before(threeMonthsAgoTime) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func lastReviewedOn(filePath string) (string, error) {
+	// Grab the last_reviewed_on date from the document.
+	// read the whole file at once
+	b, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to read file")
+	}
+
+	lines := strings.Split(string(b), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "last_reviewed_on") {
+			return strings.Split(line, ":")[1], nil
+		}
+	}
+	// find the last_reviewed_on date
+	return "", errors.New("unable to find last_reviewed_on")
+}
+
+func contains(slice []string, item string) bool {
+	set := make(map[string]struct{}, len(slice))
+	for _, s := range slice {
+		set[s] = struct{}{}
+		if _, ok := set[item]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func allDocuments(dir string) ([]string, error) {
+	// documents is a map of document names and dates to review them by.
+	ignored := []string{
+		"incident-log.html.md.erb",
+		"index.html.md.erb",
+		"custom.erb",
+	}
+
+	var documents []string
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if filepath.Ext(path) == ".erb" && !contains(ignored, info.Name()) {
+			documents = append(documents, path)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return documents, nil
+}
+
+func findTopLevelGitDir(workingDir string) (string, error) {
+	dir, err := filepath.Abs(workingDir)
+	if err != nil {
+		return "", errors.Wrap(err, "invalid working dir")
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("no git repository found")
+		}
+		dir = parent
+	}
+}

--- a/document.go
+++ b/document.go
@@ -76,7 +76,7 @@ func setLastReviewedOn(filePath string) error {
 	todaysDate := " " + time.Now().Format("2006-01-02")
 
 	o := bytes.Replace(b, []byte(lastReviewedOn), []byte(todaysDate), 1)
-	err = ioutil.WriteFile(filePath, o, 0644)
+	err = ioutil.WriteFile(filePath, o, 0o644)
 	if err != nil {
 		return errors.Wrap(err, "unable to write file")
 	}
@@ -162,29 +162,9 @@ func allDocuments(dir string) ([]string, error) {
 
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
 
 	return documents, nil
-}
-
-func findTopLevelGitDir(workingDir string) (string, error) {
-	dir, err := filepath.Abs(workingDir)
-	if err != nil {
-		return "", errors.Wrap(err, "invalid working dir")
-	}
-
-	for {
-		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
-			return dir, nil
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", errors.New("no git repository found")
-		}
-		dir = parent
-	}
 }

--- a/runbooks/source/add-concourse-to-cluster.html.md.erb
+++ b/runbooks/source/add-concourse-to-cluster.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Add Concourse to a test cluster
 weight: 51
-last_reviewed_on: 2022-05-17
+last_reviewed_on: 2022-09-02
 review_in: 3 months
 ---
 
@@ -10,27 +10,15 @@ review_in: 3 months
 ## Pre-requisites
 
 - A [test cluster][create-test-cluster]. For this guide, we'll assume it's called `david-test1`
+- You must install concourse
 - You must have [fly] installed
 
 ## Process
 
-- Go through the installation procedure in the README.md file of the [concourse repo]
-- Create a branch of the [concourse repo]
-- Create a directory for your pipelines
+- Amend the following file and remove the count line from the [concourse module](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf#L2).
+- Apply the new terraorm to your test cluster
+- Clone the concourse [repository](https://github.com/ministryofjustice/cloud-platform-terraform-concourse).
 
-```
-mkdir -p pipelines/david-test1/main
-```
-
-- Copy an existing pipeline
-
-e.g.
-
-```
-cp pipelines/manager/main/reporting.yaml pipelines/david-test1/main/
-```
-
-- Edit the pipeline yaml file as required (you probably want to remove everything relating to Pingdom)
 
 - Login via `fly`
 
@@ -55,5 +43,4 @@ Repeat this command whenever you make changes to the pipeline yaml file.
 If your pipeline requires secrets, such as AWS credentials, you need to define those as kubernetes secrets in the `concourse-main` namespace (or `concourse-<team name>` if you're using a different concourse team, rather than `main`)
 
 [create-test-cluster]: eks-cluster.html#provisioning-eks-clusters
-[concourse repo]: https://github.com/ministryofjustice/cloud-platform-terraform-concourse
 [fly]: https://concourse-ci.org/fly.html

--- a/runbooks/source/expand.html.md.erb
+++ b/runbooks/source/expand.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Expanding Persistent Volumes created using StatefulSets
 weight: 600
-last_reviewed_on: 2022-05-30
+last_reviewed_on: 2022-09-02
 review_in: 3 months
 ---
 

--- a/runbooks/source/leavers-guide.html.md.erb
+++ b/runbooks/source/leavers-guide.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Leavers Guide
 weight: 9100
-last_reviewed_on: 2022-05-31
+last_reviewed_on: 2022-09-02
 review_in: 3 months
 ---
 

--- a/runbooks/source/manually-apply-namespace.html.md.erb
+++ b/runbooks/source/manually-apply-namespace.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Manually Plan/Apply Namespace Resources
 weight: 180
-last_reviewed_on: 2022-05-26
+last_reviewed_on: 2022-09-02
 review_in: 3 months
 ---
 

--- a/runbooks/source/manually-delete-namespace-resources.html.md.erb
+++ b/runbooks/source/manually-delete-namespace-resources.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Manually Delete Namespace Resources
 weight: 185
-last_reviewed_on: 2022-05-26
+last_reviewed_on: 2022-09-02
 review_in: 3 months
 ---
 

--- a/runbooks/source/upgrade-cluster-components.html.md.erb
+++ b/runbooks/source/upgrade-cluster-components.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Upgrade cluster components
 weight: 54
-last_reviewed_on: 2022-05-17
+last_reviewed_on: 2022-09-02
 review_in: 3 months
 ---
 
@@ -56,31 +56,14 @@ aws eks --region eu-west-2 update-kubeconfig --name <cluster-name>
 
 ### Run the integration tests
 
- This is the ensure the test cluster doesnot have any existing issues and ready to use
- 
- To run ruby tests:
+This will ensure the test cluster does not have any existing issues and is ready to use.
 
-```
-cd smoke-tests
-bundle binstubs bundler --force --path /usr/local/bin
-bundle binstubs rspec-core --path /usr/local/bin
-```
+ To run Go tests:
 
 ```bash
-rspec --tag ~live-1 --tag ~kops --format progress --format documentation
+make run-tests
 ```
 
- To run golang tests:
- 
- - Update the golang config to use test cluster name
- 
- ```bash
- export CLUSTER_NAME=<test-cluster-name>
-cat ./tests/config/live.yaml |  sed -e "s/clusterName: 'live.cloud-platform.service.justice.gov.uk'/clusterName: '$CLUSTER_NAME.cloud-platform.service.justice.gov.uk'/g" > /tmp/$CLUSTER_NAME.yaml
-cd ./tests/e2e;
-go test -v -ginkgo.slowSpecThreshold=120 -config /tmp/$CLUSTER_NAME.yaml
- ```
- 
 ### Testing the upgrade
 
   1. Make the changes required to the module. For example, for upgrading the cert-manager, change the [cert-manager terraform module](https://github.com/ministryofjustice/cloud-platform-terraform-certmanager). This might include


### PR DESCRIPTION
To quickly/lazily look over document review dates in this repository. When run dynamically using `go run document.go` it will print out all documents that need review. If you've reviewed all the documents in that list and decide that they all need to have their last_review_date updated, simply add the `--fix` flag and commit.

For those lucky vim users, you can use the following command to perform a quick review:
$: vim -p \`go run document.go\`