### PR TITLE
Create Link Checker report only if the action fails

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -20,6 +20,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Issue From File
+        if: env.lychee_exit_code != 0
         uses: peter-evans/create-issue-from-file@v3
         with:
           title: Link Checker Report


### PR DESCRIPTION
This will stop creating unwanted issues everyday when there is no errors with the link checker