### PR TITLE
Add labels to support requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/cloud-platform-support-request.md
+++ b/.github/ISSUE_TEMPLATE/cloud-platform-support-request.md
@@ -1,6 +1,7 @@
 ---
 name: Cloud Platform Support Request
-about: Create new Cloud Platform Support request
+about: This template is for service teams of Cloud Platform to create a new support request
+labels: 'support team, needs refining'
 
 ---
 


### PR DESCRIPTION
This PR add "support team" labels and "needs refining" labels to the issue template that is used by service teams. This way it is easy to identify support issues during refinement and planning 