### PR TITLE
update dates, review few typos, grammar and links

### DIFF
--- a/runbooks/source/access-eks-cluster.html.md.erb
+++ b/runbooks/source/access-eks-cluster.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Access EKS Cluster
 weight: 8600
-last_reviewed_on: 2024-01-09
+last_reviewed_on: 2024-04-10
 review_in: 3 months
 ---
 

--- a/runbooks/source/change-alias-in-route53.html.md.erb
+++ b/runbooks/source/change-alias-in-route53.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Change load balancer alias to the interface IP's in Route53.
 weight: 358
-last_reviewed_on: 2024-01-09
+last_reviewed_on: 2024-04-10
 review_in: 3 months
 ---
 

--- a/runbooks/source/custom-default-backend.html.md.erb
+++ b/runbooks/source/custom-default-backend.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Custom default-backend
-last_reviewed_on: 2024-01-09
+last_reviewed_on: 2024-04-10
 weight: 9000
 review_in: 3 months
 ---

--- a/runbooks/source/destroy-concourse-build-data.html.md.erb
+++ b/runbooks/source/destroy-concourse-build-data.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Destroy Concourse Build Data
 weight: 9000
-last_reviewed_on: 2024-01-09
+last_reviewed_on: 2024-04-10
 review_in: 3 months
 ---
 
@@ -11,7 +11,7 @@ review_in: 3 months
 
 This document will briefly outline the steps required to empty the Concourse postgres persistent volume. Things to know before reading this document:
 
-- We store concourse build data in this database. After deliberation with the team it was decided that this data isn't important enough to keep, meaning the volume attached to Concourse is considered ephemeral.
+- We store concourse build data in this database. After deliberation with the team, it was decided that this data isn't important enough to keep, meaning the volume attached to Concourse is considered ephemeral.
 - Some of the steps in this document require performing a `terraform destroy` on the Concourse module, so please ensure you have valid AWS credentials and your GPG key is added to the Cloud Platform infrastructure repository.
 - The persistent volume for Concourse build data is not large (currently 8G) so will fill up over the course of a few months.
 - A low and high priority alarm will trigger for `KubePersistentVolumeFillingUp`.

--- a/runbooks/source/divergence-error.html.md.erb
+++ b/runbooks/source/divergence-error.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: How to Investigate Divergence Errors
 weight: 210
-last_reviewed_on: 2024-01-09
+last_reviewed_on: 2024-04-10
 review_in: 3 months
 ---
 

--- a/runbooks/source/expand.html.md.erb
+++ b/runbooks/source/expand.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Expanding Persistent Volumes created using StatefulSets
 weight: 600
-last_reviewed_on: 2024-01-09
+last_reviewed_on: 2024-04-10
 review_in: 3 months
 ---
 

--- a/runbooks/source/helm-repository.html.md.erb
+++ b/runbooks/source/helm-repository.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Helm Charts Repository
 weight: 710
-last_reviewed_on: 2024-01-09
+last_reviewed_on: 2024-04-10
 review_in: 3 months
 ---
 

--- a/runbooks/source/recycle-node.html.md.erb
+++ b/runbooks/source/recycle-node.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Manually run recycle node command
 weight: 250
-last_reviewed_on: 2024-01-09
+last_reviewed_on: 2024-04-10
 review_in: 3 months
 ---
 

--- a/runbooks/source/revoke-user-auth0-kubeconfig-access-token.html.md.erb
+++ b/runbooks/source/revoke-user-auth0-kubeconfig-access-token.html.md.erb
@@ -46,7 +46,7 @@ Note: Associating oidc process takes around 35 minutes.
 
 #### 2) Apply changes within components (terraform)
 
-Execute `terraform plan` inside [`cloud-platform-infrastructure/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components` directory](https://github.com/ministryofjustice/cloud-platform-infrastructure/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components)
+Execute `terraform plan` inside [`cloud-platform-infrastructure/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components` directory](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components)
 to ensure changes match kuberos resource, if they do, apply them:
 
 ```

--- a/runbooks/source/revoke-user-auth0-kubeconfig-access-token.html.md.erb
+++ b/runbooks/source/revoke-user-auth0-kubeconfig-access-token.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Revoke auth0 kubeconfig access token
 weight: 275
-last_reviewed_on: 2024-01-09
+last_reviewed_on: 2024-04-10
 review_in: 3 months
 ---
 
@@ -15,7 +15,7 @@ GitHub is being used as an OIDC provider. Once you've logged in to GitHub, it pr
 
 To revoke the tokens you need MOJ organisation administrator access, if you are not a Github admin request some one in the team who are Github admin to do it for you.
 
-Once you logged in as MOJ githib Organization administrator, go into [settings](https://github.com/organizations/ministryofjustice/settings/profile), select developer settings and Oauth [Apps](https://github.com/organizations/ministryofjustice/settings/applications) and search for "MOJ Cloud Platforms Auth0 (prod)"
+Once you logged in as MOJ github Organization administrator, go into [settings](https://github.com/organizations/ministryofjustice/settings/profile), select developer settings and Oauth [Apps](https://github.com/organizations/ministryofjustice/settings/applications) and search for "MOJ Cloud Platforms Auth0 (prod)"
 
 Click on the "Revoke all user tokens" button, this will force users to reauthenticate to get a new token.
 
@@ -46,7 +46,7 @@ Note: Associating oidc process takes around 35 minutes.
 
 #### 2) Apply changes within components (terraform)
 
-Execute `terraform plan` inside [`cloud-platform-infrastructure/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components` directory](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components)
+Execute `terraform plan` inside [`cloud-platform-infrastructure/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components` directory](https://github.com/ministryofjustice/cloud-platform-infrastructure/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components)
 to ensure changes match kuberos resource, if they do, apply them:
 
 ```

--- a/runbooks/source/scheduled-pr-reminders.html.md.erb
+++ b/runbooks/source/scheduled-pr-reminders.html.md.erb
@@ -1,13 +1,13 @@
 ---
 title: Scheduled PR Reminders
 weight: 9101
-last_reviewed_on: 2024-01-09
+last_reviewed_on: 2024-04-10
 review_in: 3 months
 ---
 
 # Scheduled PR Reminders
 
-Scheduled reminders helps the Cloud Platform focus on the most important review requests that require their attention. Scheduled reminders for pull requests will send a message to various Slack channels with all open pull requests that the team have been asked to review (or need merging), at a specified time. For example, you can create a scheduled reminder to send a message to your team's main communication channel in Slack, including all open pull requests that the team is requested to review, every Wednesday at 9:00 a.m.
+Scheduled reminders help the Cloud Platform focus on the most important review requests that require their attention. Scheduled reminders for pull requests will send a message to various Slack channels with all open pull requests that the team have been asked to review (or need merging), at a specified time. For example, you can create a scheduled reminder to send a message to your team's main communication channel in Slack, including all open pull requests that the team is requested to review, every Wednesday at 9:00 a.m.
 
 All reminders are created on Github Team level - For the Cloud Platform team, the team is `webops`
 


### PR DESCRIPTION
Reviewed the following docs in the Runbooks:

- Scheduled PR Reminders
- Expanding Persistent Volumes created using StatefulSets
- Change load balancer alias to the interface IP's in Route53
- Manually run recycle node command
- Revoke auth0 kubeconfig access token
- How to Investigate Divergence Errors
- Access EKS Cluster
- Custom default-backend
- Destroy Concourse Build Data
- Helm Charts Repository

Corrected few grammar and typos, all links work except those that require GitHub organization admin access in the Revoke auth0 kubeconfig access token doc.