### PR TITLE
feat: add workflow for staling prs and issues

### DIFF
--- a/.github/workflows/issue-pr-staler.yml
+++ b/.github/workflows/issue-pr-staler.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/stale@v9
         with:
           stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
-          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
           exempt-pr-labels: dependencies
           days-before-stale: 60

--- a/.github/workflows/issue-pr-staler.yml
+++ b/.github/workflows/issue-pr-staler.yml
@@ -1,0 +1,23 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  contents: write # only for delete-branch option
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+          exempt-pr-labels: dependencies
+          days-before-stale: 60
+          days-before-close: 7
+          days-before-pr-close: -1


### PR DESCRIPTION
## 👀 Purpose

- Cloud Platform GitHub Project are kept in this repo, and this has led to a large number of abandoned GitHub issues that aren't active or planned for future work. It would be preferable to automatically mark these issues for automated closing, then close them.

## ♻️ What's changed

- Uses available action to adds `Stale` label to issues (Cloud Platform GitHub Project are kept in this repo) and PRs that haven't been interacted with for 60 days, then close issues after 7 days (PRs aren't automatically closed)

## 📝 Notes

- dependabot PRs are ignored by this action (those PRs tagged with the `dependencies` label)