### PR TITLE
style: exempt issues with `future` label from stale

### DIFF
--- a/.github/workflows/issue-pr-staler.yml
+++ b/.github/workflows/issue-pr-staler.yml
@@ -1,10 +1,10 @@
-name: 'Close stale issues and PRs'
+name: 'Stale and close issues and PRs'
+
 on:
   schedule:
     - cron: '30 1 * * *'
 
 permissions:
-  contents: write # only for delete-branch option
   issues: write
   pull-requests: write
 
@@ -17,6 +17,7 @@ jobs:
           stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           stale-pr-message: 'This PR is stale because it has been open 60 days with no activity.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+          exempt-issue-labels: future
           exempt-pr-labels: dependencies
           days-before-stale: 60
           days-before-close: 7


### PR DESCRIPTION
## 👀 Purpose

- don't pre-emptively `stale` issues that haven't been worked on yet

## ♻️ What's changed

- tweak the issue staler to exempt issues with `future` labels on

## 📝 Notes

-