### PR TITLE
docs: ✏️ update latest container images

### DIFF
--- a/runbooks/source/container-images.html.md.erb
+++ b/runbooks/source/container-images.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Container Images used by Cluster Components
 weight: 55
-last_reviewed_on: 2024-10-09
+last_reviewed_on: 2024-11-14
 review_in: 3 months
 ---
 
@@ -19,9 +19,9 @@ To grab the current image versions for all containers within components namespac
 kubectl get pods -n [NAMESPACE] -o jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{end}' | sort
 ```
 
-### Latest version for k8s 1.28
+### Latest version for k8s 1.29
 
-The latest versions of some of the components might not be compatible with k8s 1.28. For this, click the link to check the Compatibility Matrix
+The latest versions of some of the components might not be compatible with k8s 1.29. For this, click the link to check the Compatibility Matrix
 
 ### Latest version available
 That's the latest version available in the public repository. Update the version when there is a new release. You can find the latest version by clicking on the link or by checking the
@@ -41,122 +41,126 @@ This depends on several factors, some of them are:
 🔴 - urgent, within this sprint
 
 ## calico-apiserver
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
-| docker.io/calico/apiserver:v3.25.0 | 🟢 | [v3.28.0](https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements#kubernetes-requirements) |[v3.28.0](https://github.com/projectcalico/calico/releases/tag/v3.28.0) | [v1.34.1](https://github.com/tigera/operator/releases/tag/v1.34.1) |
+| docker.io/calico/apiserver:v3.28.1 | 🟠 | [v3.29.0](https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements#kubernetes-requirements) |[v3.29.0](https://github.com/projectcalico/calico/releases/tag/v3.29.0) | [v1.36.1](https://github.com/tigera/operator/releases/tag/v1.36.1) |
 
 ## calico-system
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
-| docker.io/calico/csi:v3.25.0 | 🟢 | [v3.28.0](https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements#kubernetes-requirements) | [v3.28.0](https://github.com/projectcalico/calico/releases/tag/v3.28.0) | [v1.34.1](https://github.com/tigera/operator/releases/tag/v1.34.1) |
-| docker.io/calico/kube-controllers:v3.25.0 | 🟢 | v3.28.0 | [v3.28.0](https://github.com/projectcalico/calico/releases/tag/v3.28.0) | [v1.34.1](https://github.com/tigera/operator/releases/tag/v1.34.1) |
-| docker.io/calico/node-driver-registrar:v3.25.0 | 🟢 | v3.28.0 | [v3.28.0](https://github.com/projectcalico/calico/releases/tag/v3.28.0) | [v1.34.1](https://github.com/tigera/operator/releases/tag/v1.34.1) |
-| docker.io/calico/node:v3.25.0 | 🟢 | v3.28.0 | [v3.28.0](https://github.com/projectcalico/calico/releases/tag/v3.28.0) | [v1.34.1](https://github.com/tigera/operator/releases/tag/v1.34.1) |
-| docker.io/calico/typha:v3.25.0 | 🟢 | v3.28.0 | [v3.28.0](https://github.com/projectcalico/calico/releases/tag/v3.28.0) | [v1.34.1](https://github.com/tigera/operator/releases/tag/v1.34.1) |
+| docker.io/calico/csi:v3.28.1 | 🟠 | [v3.29.0](https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements#kubernetes-requirements) |[v3.29.0](https://github.com/projectcalico/calico/releases/tag/v3.29.0) | [v1.36.1](https://github.com/tigera/operator/releases/tag/v1.36.1) |
+| docker.io/calico/kube-controllers:v3.28.1 | 🟠 | [v3.29.0](https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements#kubernetes-requirements) |[v3.29.0](https://github.com/projectcalico/calico/releases/tag/v3.29.0) | [v1.36.1](https://github.com/tigera/operator/releases/tag/v1.36.1) |
+| docker.io/calico/node-driver-registrar:v3.28.1 | 🟠 | [v3.29.0](https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements#kubernetes-requirements) |[v3.29.0](https://github.com/projectcalico/calico/releases/tag/v3.29.0) | [v1.36.1](https://github.com/tigera/operator/releases/tag/v1.36.1) |
+| docker.io/calico/node:v3.28.1 | 🟠 | [v3.29.0](https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements#kubernetes-requirements) |[v3.29.0](https://github.com/projectcalico/calico/releases/tag/v3.29.0) | [v1.36.1](https://github.com/tigera/operator/releases/tag/v1.36.1) |
+| docker.io/calico/typha:v3.28.1 | 🟠 | [v3.29.0](https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements#kubernetes-requirements) |[v3.29.0](https://github.com/projectcalico/calico/releases/tag/v3.29.0) | [v1.36.1](https://github.com/tigera/operator/releases/tag/v1.36.1) |
 
 ## cert-manager
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
-| quay.io/jetstack/cert-manager-cainjector:v1.13.1 | 🟢 | [v1.15.0](https://cert-manager.io/docs/releases/#currently-supported-releases) | [v1.15.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.15.0) | [v1.15.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.15.0) |
-| quay.io/jetstack/cert-manager-controller:v1.13.1 | 🟢 | [v1.15.0](https://cert-manager.io/docs/releases/#currently-supported-releases) | [v1.15.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.15.0) | [v1.15.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.15.0) |
-| quay.io/jetstack/cert-manager-webhook:v1.13.1 | 🟢 | [v1.15.0](https://cert-manager.io/docs/releases/#currently-supported-releases) | [v1.15.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.15.0) | [v1.15.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.15.0) |
+| quay.io/jetstack/cert-manager-cainjector:v1.13.1 | 🟠 | [v1.16.0](https://cert-manager.io/docs/releases/#currently-supported-releases) | [v1.16.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.16.1) | [v1.16.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.16.1) |
+| quay.io/jetstack/cert-manager-controller:v1.13.1 | 🟠 | [v1.16.0](https://cert-manager.io/docs/releases/#currently-supported-releases) | [v1.16.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.16.1) | [v1.16.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.16.1) |
+| quay.io/jetstack/cert-manager-webhook:v1.13.1 | 🟠 | [v1.16.0](https://cert-manager.io/docs/releases/#currently-supported-releases) | [v1.16.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.16.1) | [v1.16.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.16.1) |
 
 ## concourse
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
-| concourse/concourse:7.10.0 | 🟢 | [v7.11.2](https://github.com/concourse/concourse/releases) | [v7.11.2](https://github.com/concourse/concourse/releases) | [v17.3.1](https://github.com/concourse/concourse-chart/releases/tag/v17.3.1)
+| concourse/concourse:7.10.0 | 🟢 | [v7.12.0](https://github.com/concourse/concourse/releases) | [v7.12.0](https://github.com/concourse/concourse/releases) | [v17.3.1](https://github.com/concourse/concourse-chart/releases/tag/v17.3.1)
 
 ## external-secrets-operator
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
-| ghcr.io/external-secrets/external-secrets:v0.8.1 | 🟢 | [v0.9.19](https://external-secrets.io/latest/introduction/stability-support/#supported-versions) | [v0.9.19](https://github.com/external-secrets/external-secrets/releases/tag/v0.9.19)  | [v0.9.19](https://github.com/external-secrets/external-secrets/releases/tag/helm-chart-0.9.19)
+| ghcr.io/external-secrets/external-secrets:v0.8.1 | 🟢 | [v0.10.5](https://external-secrets.io/latest/introduction/stability-support/#supported-versions) | [v0.10.15](https://github.com/external-secrets/external-secrets/releases/tag/v0.10.15)  | [v0.10.5](https://github.com/external-secrets/external-secrets/releases/tag/helm-chart-0.10.5)
 
 ## gatekeeper-system
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
-|-|-|-|-|-|
-| openpolicyagent/gatekeeper:v3.15.1: | 🟢 | v3.15.1 | [v3.16.3](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.16.3) | [v3.16.3](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.16.3) |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
+|-|-|-|-|-r
+| openpolicyagent/gatekeeper:v3.15.1: | 🟠 | v3.17.1 | [v3.17.1](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.17.1) | [v3.17.1](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.17.1) |
 
 ## ingress-controllers
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
-| debian:bookworm-slim | 🟢 | latest | n/a |
-| fluent/fluent-bit:3.0.2-amd64 | 🟢 | v3.0.7 | [v3.0.7](https://github.com/fluent/fluent-bit/releases/tag/v3.0.7) | n/a |
-| ministryofjustice/cloud-platform-custom-error-pages:0.6 | 🟠 | [managed by us](https://github.com/ministryofjustice/cloud-platform-custom-error-pages) | [managed by us](https://github.com/ministryofjustice/cloud-platform-custom-error-pages/releases/tag/1.1.3) | n/a |
-| registry.k8s.io/ingress-nginx/controller:v1.8.4| 🟢 | [v1.10.1](https://github.com/kubernetes/ingress-nginx?tab=readme-ov-file#supported-versions-table) | [v1.10.1](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.10.1) | [v4.10.1](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx)
+| debian:bookworm-slim::bookworm-20241016-slim | 🟢 | latest | n/a |
+| fluent/fluent-bit:3.0.2-amd64 | 🟢 | v3.1.10 | [v3.1.10](https://github.com/fluent/fluent-bit/releases/tag/v3.1.10) | n/a |
+| ministryofjustice/cloud-platform-custom-error-pages:1.1.5 | 🟢 | [managed by us](https://github.com/ministryofjustice/cloud-platform-custom-error-pages) | [managed by us](https://github.com/ministryofjustice/cloud-platform-custom-error-pages/releases/tag/1.1.5) | n/a |
+| registry.k8s.io/ingress-nginx/controller:v1.10.1| 🟢 | [v1.11.3](https://github.com/kubernetes/ingress-nginx?tab=readme-ov-file#supported-versions-table) | [v1.11.3](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.11.3) | [v4.11.3](https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.11.3)
 
 ## kube-system
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
-| 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon-k8s-cni:v1.18.2-eksbuild.1 | 🟢 | [v1.18.2-eksbuild.1](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html) | [v1.18.2-eksbuild.1](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html) | n/a |
-| 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.2-eksbuild.1 | 🟢 | [v1.1.2-eksbuild.1](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html) | [v1.1.2-eksbuild.1](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html) | n/a
-| 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/coredns:v1.10.1-eksbuild.11 | 🟢 | [v1.10.1-eksbuild.11](https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html) | [v1.11.1-eksbuild.9](https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html) | n/a |
-| 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-proxy:v1.28.8-minimal-eksbuild.5 | 🟢 | [v1.28.8-eksbuild.5](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html) | [v1.30.0-eksbuild.3](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html) | n/a
-| docker.io/bitnami/external-dns:0.13.4-debian-11-r14 | 🟢 | v0.14.x | [v0.14.x](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.14.0) | [v0.14.x](https://github.com/bitnami/charts/blob/main/bitnami/external-dns/Chart.yaml#L11) |
-| public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.29.1 | 🟢 | [v1.30.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver?tab=readme-ov-file#compatibility) | [v1.30.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/v1.30.0) | [2.30.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.30.0) |
-| public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.5.0-eks-1-29-7 | 🟢 | [v4.5.0](https://distro.eks.amazonaws.com/releases/1-26/28/) | [v1.30.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/v1.29.1) | [2.30.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.30.0) |
-| public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v4.0.0-eks-1-29-7 | 🟢 | [v4.0.0](https://distro.eks.amazonaws.com/releases/1-26/28/) | [v1.30.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/v1.29.1) | [2.30.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.30.0) |
-| public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.10.0-eks-1-29-7 | 🟢 | [v1.10.0](https://distro.eks.amazonaws.com/releases/1-26/28/) | [v1.30.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/v1.29.1) | [2.30.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.30.0) |
-| public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.12.0-eks-1-29-7 | 🟢 | [v2.12.0](https://distro.eks.amazonaws.com/releases/1-26/28/) | [v1.30.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/v1.29.1) | [2.30.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.30.0) |
-| public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.10.0-eks-1-29-7 | 🟢 | [v2.10.0](https://distro.eks.amazonaws.com/releases/1-26/28/) | [v1.30.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/v1.29.1)  | [2.30.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.30.0) |
-| registry.k8s.io/autoscaling/cluster-autoscaler:v1.28.5 | 🟢 | [v1.28.5](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases) | [v1.30.1](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.30.1) | [9.37.0](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-chart-9.37.0) |
-| registry.k8s.io/descheduler/descheduler:v0.27.1 | 🟢 | [v0.27.1](https://github.com/kubernetes-sigs/descheduler?tab=readme-ov-file#%EF%B8%8F--documentation-versions-by-release) | [v0.29.0](https://github.com/kubernetes-sigs/descheduler/releases/tag/v0.29.0) | [0.29.0](https://github.com/kubernetes-sigs/descheduler/releases/tag/descheduler-helm-chart-0.29.0) |
-| registry.k8s.io/metrics-server/metrics-server:v0.7.1 | 🟢 | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server?tab=readme-ov-file#compatibility-matrix) | [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1) | [3.12.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/metrics-server-helm-chart-3.12.1) |
+| 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon-k8s-cni:v1.18.2-eksbuild.1 | 🟢 | [v1.18.6-eksbuild.1](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html) | [v1.18.B-eksbuild.1](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html) | n/a |
+| 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.1.2 | 🟢 | [v1.1.4](https://github.com/aws/aws-network-policy-agent/releases/tag/v1.1.4) | [v1.1.4](https://github.com/aws/aws-network-policy-agent/releases/tag/v1.1.4) | n/a
+| 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/coredns:v1.10.1-eksbuild.11 | 🟢 | [v1.11.3-eksbuild.11](https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html) | [v1.11.3-eksbuild.9](https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html) | n/a |
+| 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-proxy:v1.28.8-minimal-eksbuild.5 | 🟢 | [v1.29.10-minimal-eksbuild.2](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html#managing-kube-proxy-images) | [v1.31.1-minimal-eksbuild.2](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html) | n/a
+| docker.io/bitnami/external-dns:0.13.4-debian-11-r14 | 🟠 | v0.15.x | [v0.15.x](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.15.0) | [v0.15.x](https://github.com/bitnami/charts/blob/main/bitnami/external-dns/Chart.yaml#L11) |
+| registry.k8s.io/autoscaling/cluster-autoscaler:v1.28.5 | 🟢 | [v1.29.4](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.29.4) | [v1.31.0](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.31.0) | [9.38.0](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-chart-9.38.0) |
+| registry.k8s.io/descheduler/descheduler:v0.27.1 | 🟠 | [v0.29.x](https://github.com/kubernetes-sigs/descheduler?tab=readme-ov-file#%EF%B8%8F--documentation-versions-by-release) | [v0.29.0](https://github.com/kubernetes-sigs/descheduler/releases/tag/v0.29.0) | [0.31.0](https://github.com/kubernetes-sigs/descheduler/releases/tag/descheduler-helm-chart-0.31.0) |
+| registry.k8s.io/metrics-server/metrics-server:v0.7.1 | 🟢 | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server?tab=readme-ov-file#compatibility-matrix) | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) | [3.12.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/metrics-server-helm-chart-3.12.2) |
+
+#### included with the ebs-cbs-driver in `kube-system`
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
+|-|-|-|-|-|
+| public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.29.1 | 🟠 | [v1.37.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases) | [v1.37.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/v1.37.0) | [2.37.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.37.0) |
+| public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.5.0-eks-1-29-7 | 🟠 | [v4.7.0](https://distro.eks.amazonaws.com/releases/1-29/24/) | [v1.37.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/v1.37.0) | [2.37.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.37.0) |
+| public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v4.0.0-eks-1-29-7 | 🟠 | [v5.1.0](https://distro.eks.amazonaws.com/releases/1-29/24/) | [v1.37.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/v1.37.0) | [2.37.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.37.0) |
+| public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.10.0-eks-1-29-7 | 🟠 | [v1.12.0](https://distro.eks.amazonaws.com/releases/1-29/24/) | [v1.37.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/v1.37.0) | [2.37.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.37.0) |
+| public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.12.0-eks-1-29-7 | 🟠 | [v2.14.0](https://distro.eks.amazonaws.com/releases/1-29/24/) | [v1.37.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/v1.37.0) | [2.37.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.37.0) |
+| public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.10.0-eks-1-29-7 | 🟠 | [v2.12.0](https://distro.eks.amazonaws.com/releases/1-29/24/) | [v1.37.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/v1.37.0)  | [2.37.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.37.0) |
 
 ## kuberhealthy
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
 | 754256621582.dkr.ecr.eu-west-2.amazonaws.com/webops/cloud-platform-kuberhealthy-checks:1.9 | 🟢 | managed by us | [1.9](https://github.com/ministryofjustice/cloud-platform-kuberhealthy-checks/releases/tag/1.9) | n/a |
-| docker.io/kuberhealthy/daemonset-check:v3.3.0 | 🟢 | v3.3.0 | [v3.3.0](https://github.com/kuberhealthy/kuberhealthy/releases/tag/v2.7.1) | [104](https://github.com/kuberhealthy/kuberhealthy/tree/master/deploy/helm/kuberhealthy) |
-| docker.io/kuberhealthy/deployment-check:v1.9.0 | 🟢 | v1.9.0 | [v3.3.0](https://github.com/kuberhealthy/kuberhealthy/releases/tag/v2.7.1) | [104](https://github.com/kuberhealthy/kuberhealthy/tree/master/deploy/helm/kuberhealthy) |
-| docker.io/kuberhealthy/dns-resolution-check:v1.5.0 | 🟢 | v1.5.0 | [v3.3.0](https://github.com/kuberhealthy/kuberhealthy/releases/tag/v2.7.1) | [104](https://github.com/kuberhealthy/kuberhealthy/tree/master/deploy/helm/kuberhealthy) |
-| docker.io/kuberhealthy/kuberhealthy:v2.8.0-rc2 __[pre-release]__| 🟢 | v2.7.1 | [v3.3.0](https://github.com/kuberhealthy/kuberhealthy/releases/tag/v2.7.1) | [104](https://github.com/kuberhealthy/kuberhealthy/tree/master/deploy/helm/kuberhealthy) |
+| docker.io/kuberhealthy/daemonset-check:v3.3.0 | 🟢 | v3.3.0 | [v2.7.1](https://github.com/kuberhealthy/kuberhealthy/releases/tag/v2.7.1) | [104](https://github.com/kuberhealthy/kuberhealthy/tree/master/deploy/helm/kuberhealthy) |
+| docker.io/kuberhealthy/deployment-check:v1.9.0 | 🟢 | v1.9.1 | [v2.7.1](https://github.com/kuberhealthy/kuberhealthy/releases/tag/v2.7.1) | [104](https://github.com/kuberhealthy/kuberhealthy/tree/master/deploy/helm/kuberhealthy) |
+| docker.io/kuberhealthy/dns-resolution-check:v1.5.0 | 🟢 | v1.5.0 | [v2.7.1](https://github.com/kuberhealthy/kuberhealthy/releases/tag/v2.7.1) | [104](https://github.com/kuberhealthy/kuberhealthy/tree/master/deploy/helm/kuberhealthy) |
+| docker.io/kuberhealthy/kuberhealthy:v2.8.0-rc2 __[pre-release]__| 🟢 | v2.7.1 | [v2.7.1](https://github.com/kuberhealthy/kuberhealthy/releases/tag/v2.7.1) | [104](https://github.com/kuberhealthy/kuberhealthy/tree/master/deploy/helm/kuberhealthy) |
 
 ## kuberos
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
 | ministryofjustice/cloud-platform-kuberos:2.7.0 | 🟢 | managed by us | [0.4.0](https://github.com/ministryofjustice/cloud-platform-helm-charts/tree/main/kuberos) | [0.4.0](https://github.com/ministryofjustice/cloud-platform-helm-charts/tree/main/kuberos)
 
 ## logging
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
-| fluent/fluent-bit:2.2.1 | 🟠  | v3.0.2 | [v3.0.7](https://github.com/fluent/fluent-bit/releases/tag/v3.0.7) | [0.46.11](https://github.com/fluent/helm-charts) |
+| fluent/fluent-bit:2.2.1 | 🔴 | v3.1.10 | [v3.1.10](https://github.com/fluent/fluent-bit/releases/tag/v3.1.10) | [0.47.11](https://github.com/fluent/helm-charts) |
 
 ## monitoring
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
-| docker.io/bitnami/redis:7.2.4-debian-11-r5 | 🟢 | v7.2.5-debian-12-r1 | [v7.2.5-debian-12-r1](https://hub.docker.com/layers/bitnami/redis/7.2.5-debian-12-r1/images/sha256-4c7ac96a3d576ce06603c2809d32f0c0e1754699aeb5bc3cb727d158d14caefd?context=explore | n/a |
-| docker.io/bitnami/thanos:0.34.1-debian-12-r1 | 🟢 | v0.36.0 | [v0.36.0](https://github.com/thanos-io/thanos/releases/tag/v0.36.0-rc.0)  | [v0.35.1](https://github.com/bitnami/charts/blob/main/bitnami/thanos/Chart.yaml#L13) |
-| docker.io/grafana/grafana:10.4.0 | 🟠 | v11.1.0| [v11.1.0](https://github.com/grafana/grafana/releases/tag/v11.1.0) | [60.4.0](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
+| docker.io/bitnami/redis:7.2.4-debian-11-r5 | 🟢 | 7.4.1-debian-12-r2 | [v7.4.1-debian-12-r2](https://hub.docker.com/layers/bitnami/redis/7.4.1-debian-12-r2/images/sha256-3413f16342b05f07b31c246240b8bf2295553c46c7b81294f88e2855ba1cb026?context=explore) | n/a |
+| docker.io/bitnami/thanos:0.34.1-debian-12-r1 | 🟠 | v0.36.1 | [v0.36.1](https://github.com/thanos-io/thanos/releases/tag/v0.36.1)  | [v0.36.1](https://github.com/bitnami/charts/blob/main/bitnami/thanos/Chart.yaml#L13) |
+| docker.io/grafana/grafana:10.4.0 | 🟠 | v11.3.0+security-01| [v11.3.0+security-01](https://github.com/grafana/grafana/releases/tag/v11.3.0%2Bsecurity-01) | [66.1.1](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
 | ministryofjustice/prometheus-ecr-exporter:0.2.0 | 🟢 | managed by us | n/a | [0.4.0](https://github.com/ministryofjustice/cloud-platform-helm-charts/blob/main/prometheus-ecr-exporter/Chart.yaml#L5) |
 | ghcr.io/nerdswords/yet-another-cloudwatch-exporter:v0.61.2 | 🟢 | v0.61.2 | [v0.61.2](https://github.com/nerdswords/yet-another-cloudwatch-exporter/releases) | [0.38.0](https://github.com/nerdswords/helm-charts/releases)
-| quay.io/kiwigrid/k8s-sidecar:1.26.1 | 🟢 | v1.26.2 |  [v1.26.2](https://github.com/kiwigrid/k8s-sidecar/releases/tag/1.26.2) | [60.4.0](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
-| quay.io/oauth2-proxy/oauth2-proxy:v7.6.0 | 🟢 | v7.6.0 | [v7.6.0](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.6.0) | [7.7.7](https://github.com/oauth2-proxy/manifests/releases/tag/oauth2-proxy-7.7.7) |
-| quay.io/prometheus-operator/prometheus-config-reloader:v0.72.0 | 🟢 | v0.75.0 | [v0.75.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.73.0) | [60.4.0](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
-| quay.io/prometheus-operator/prometheus-operator:v0.72.0 | 🟢 | v0.75.0 | [v0.75.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.75.0) | [60.4.0](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
+| quay.io/kiwigrid/k8s-sidecar:1.26.1 | 🟠 | v1.28.0 |  [v1.28.0](https://github.com/kiwigrid/k8s-sidecar/releases/tag/1.28.0) | [66.1.1](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
+| quay.io/oauth2-proxy/oauth2-proxy:v7.6.0 | 🟠 | v7.7.1 | [v7.7.1](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.7.1) | [7.7.29](https://github.com/oauth2-proxy/manifests/releases/tag/oauth2-proxy-7.7.29) |
+| quay.io/prometheus-operator/prometheus-config-reloader:v0.72.0 | 🔴 | v0.78.1 | [v0.78.1](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.78.1) | [66.1.1](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
+| quay.io/prometheus-operator/prometheus-operator:v0.72.0 | 🔴 | v0.78.1 | [v0.78.1](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.78.1) | [66.1.1](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
 | quay.io/prometheus/alertmanager:v0.27.0 | 🟢 | v0.27.0 |  [v0.27.0](https://github.com/prometheus/alertmanager/releases/tag/v0.27.0) | [60.4.0](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
-| quay.io/prometheus/node-exporter:v1.7.0 | 🟢 | v1.7.0 |  [v1.8.1](https://github.com/prometheus/node_exporter/releases/tag/v1.8.1) | [60.4.0](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
-| quay.io/prometheus/prometheus:v2.51.0 | 🟢 | v2.53.0 |  [v2.53.0](https://github.com/prometheus/prometheus/releases/tag/v2.53.0)  | [60.4.0](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
-| quay.io/thanos/thanos:v0.33.0 | 🟢 | v0.36.0 | [v0.36.0](https://github.com/thanos-io/thanos/releases/tag/v0.36.0-rc.0) | [60.4.0](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
-| registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.11.0 | 🟢 | [v2.10.1](https://github.com/kubernetes/kube-state-metrics?tab=readme-ov-file#compatibility-matrix)   | [2.12.0](https://github.com/kubernetes/kube-state-metrics/releases) |  [60.4.0](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
+| quay.io/prometheus/node-exporter:v1.7.0 | 🟢 | v1.7.0 |  [v1.8.2](https://github.com/prometheus/node_exporter/releases/tag/v1.8.2) | [60.4.0](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
+| quay.io/prometheus/prometheus:v2.51.0 | 🟢 | v3.0.0 |  [v3.0.0](https://github.com/prometheus/prometheus/releases/tag/v3.0.0)  | [66.1.1](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
+| quay.io/thanos/thanos:v0.33.0 | 🔴 | v0.36.0 | [v0.36.0](https://github.com/thanos-io/thanos/releases/tag/v0.36.0-rc.0) | [60.4.0](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
+| registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.11.0 | 🟠 | [v2.13.0](https://github.com/kubernetes/kube-state-metrics?tab=readme-ov-file#compatibility-matrix)   | [2.13.0](https://github.com/kubernetes/kube-state-metrics/releases) |  [66.1.1](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L26) |
 
 ## overprovision
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
 | registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.6 | 🟢 | v1.8.9 | [v1.8.9](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/releases/tag/v1.8.9) | [1.1.0](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/tree/master/charts/cluster-proportional-autoscaler)
 | registry.k8s.io/pause:3.9 | 🟢 | v3.9 | [v3.9](https://github.com/kubernetes/kubernetes/tree/master/build/pause) | [registry](https://github.com/kubernetes/registry.k8s.io/blob/main/docs/debugging.md#verify-image-repositories-and-tags) |
 
 ## tigera-operator
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
-| quay.io/tigera/operator:v1.30.0 | 🟠 | v1.34.1 | [v1.34.1](https://github.com/tigera/operator/releases/tag/v1.34.1) | [3.28.0](https://github.com/projectcalico/calico/tree/master/charts/tigera-operator)
+| quay.io/tigera/operator:v1.30.0 | 🔴 | v1.36.1 | [v1.36.1](https://github.com/tigera/operator/releases/tag/v1.36.1) | [3.28.0](https://github.com/projectcalico/calico/tree/master/charts/tigera-operator)
 
 ## trivy-system
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
-| ghcr.io/aquasecurity/trivy-operator:0.16.4 | 🟠 | v0.21.3| [v0.21.3](https://github.com/aquasecurity/trivy-operator/releases/tag/v0.21.3) | [0.23.3](https://github.com/aquasecurity/trivy-operator/blob/main/deploy/helm/Chart.yaml)
-| ghcr.io/aquasecurity/trivy:0.47.0 | 🟠 | v0.52.2 | [v0.52.2](https://github.com/aquasecurity/trivy/releases) | [0.23.3](https://github.com/aquasecurity/trivy-operator/blob/main/deploy/helm/Chart.yaml)
+| ghcr.io/aquasecurity/trivy-operator:0.16.4 | 🔴 | v0.22.0| [v0.22.0](https://github.com/aquasecurity/trivy-operator/releases/tag/v0.22.0) | [0.22.0](https://github.com/aquasecurity/trivy-operator/blob/main/deploy/helm/Chart.yaml)
+| ghcr.io/aquasecurity/trivy:0.47.0 | 🔴 | v0.57.0 | [v0.57.0](https://github.com/aquasecurity/trivy/releases) | [0.24.1](https://github.com/aquasecurity/trivy-operator/blob/main/deploy/helm/Chart.yaml)
 
 ## velero
-| container image | urgency | latest version for k8s 1.28 | latest version available | latest helm chart |
+| container image | urgency | latest version for k8s 1.29 | latest version available | latest helm chart |
 |-|-|-|-|-|
-| velero/velero:v1.13.0 | 🟢 | [v1.14.0](https://github.com/vmware-tanzu/velero?tab=readme-ov-file#velero-compatibility-matrix) | [v1.14.0](https://github.com/vmware-tanzu/velero/releases) | [ 7.0.0](https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/Chart.yaml) |
+| velero/velero:v1.13.0 | 🔴 | [v1.15.0](https://github.com/vmware-tanzu/velero?tab=readme-ov-file#velero-compatibility-matrix) | [v1.15.0](https://github.com/vmware-tanzu/velero/releases) | [8.0.0](https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/Chart.yaml) |


### PR DESCRIPTION
Following the k8s cluster upgrade upgrade the latest container images we can use doc