### PR TITLE
Fix command example

### DIFF
--- a/runbooks/source/manually-delete-namespace-resources.html.md.erb
+++ b/runbooks/source/manually-delete-namespace-resources.html.md.erb
@@ -54,7 +54,7 @@ Locate the PR number for the namespace deletion PR, and execute the following co
 
 ```bash
 cloud-platform environment destroy \
-    --prNumber [namespace-deletion-PR] \
+    --pr-number [namespace-deletion-PR] \
     --cluster arn:aws:eks:eu-west-2:754256621582:cluster/live \
     --kubecfg ~/.kube/config \
     --clusterdir live.cloud-platform.service.justice.gov.uk \


### PR DESCRIPTION
Fixing the command example for `cloud-platform environment destroy` as it uses `--pr-number` instead of `--prNumber`.