### PR TITLE
Update Joiners Guide to replace Google Workspace entries with M365 ones

### DIFF
--- a/runbooks/source/joiners-guide.html.md.erb
+++ b/runbooks/source/joiners-guide.html.md.erb
@@ -18,7 +18,7 @@ review_in: 6 months
 
 * Supply IT kit
 * Lockers
-* Google Account
+* Microsoft 365 Account
 * Relevant mailing-list
 
 ## Sit down with DM
@@ -30,8 +30,7 @@ review_in: 6 months
 * Roles in team
 * How does the team work internally - org chart
 * Invite to slack channel(s): #cloud-platform and others mentioned in [operational processes](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/reference/operational-processes.html) as appropriate
-* Invite to [mail group](https://groups.google.com/a/digital.justice.gov.uk/g/platforms/members)
-* Invite to [calendar](https://calendar.google.com/calendar/u/0?cid=ZGlnaXRhbC5qdXN0aWNlLmdvdi51a18yaDlqNnR1ZGJwNjEwYjA0N2txaGhkazVub0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
+* Invite to [M365 group](https://outlook.office.com/groups/JusticeUK.onmicrosoft.com/CloudPlatform/members/inbox)
 * Timesheets
 
 ## Cloud Platform team


### PR DESCRIPTION
I updated the Joiners Guide in the Cloud Platform Runbooks to replace the previous reference to Google Groups & Calendar with the Microsoft 365 replacement