### PR TITLE
fix invalid date

### DIFF
--- a/runbooks/source/logs-to-soc-cortex-xsiam.html.md.erb
+++ b/runbooks/source/logs-to-soc-cortex-xsiam.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Logs going to SOC Palo Alto Cortex Xsiam
 weight: 9100
-last_reviewed_on: 2025-06-203
+last_reviewed_on: 2025-07-02
 review_in: 6 months
 ---
 


### PR DESCRIPTION
The runbook entry was not published because of a typo in last reviewed date.