### PR TITLE
Update leaver's guide after Google Workspace Decommissioning

### DIFF
--- a/runbooks/source/leavers-guide.html.md.erb
+++ b/runbooks/source/leavers-guide.html.md.erb
@@ -13,22 +13,17 @@ When CP team members leave, follow this guide, and log completion in a ticket.
 
 ### Digital Services
 
-#### Google account closure
-  This has to be ordered in advance of them leaving, by creating a ServiceNow order [Return device for Digital Mac & WTP users](https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=a1f163211bb1a8507b10ca286e4bcb7a)
-
-  This is not just about returning their Mac - it will do the important step of closing their Google account.
+#### Equipment Return (including MacBook) and Accounts Closure
+Only use this bundle to return, Digital MacBook’s and WTP devices. [Leaver Bundle – Digital
+](https://mojprod.service-now.com/moj_sp?id=sc_cat_item_guide&table=sc_cat_item&sys_id=61565d171b900510f58d206fe54bcbfa)
 
   This is usually raised by the line manager for civil servants.
 
-  * Note - Include details in the ServiceNow request to transfer the leaver's Google Drive to someone in their team.
+  * Note - It is no longer possible to transfer a leaver's documents, etc. to another person as part of the leaver's process please transfer any documents to a suitable place before they leave.
 
   * Note - If the leaver has created any slack apps, these will need to be transferred to someone else in the team.
 
   Contact #digital-it-forum channel for any queries
-
-#### MOJ Digital VPN removal
-  Create a ServiceNow order: [Digital VPN add/remove](https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=6860adc01b8b6818f58d206fe54bcbe3)
-  This is usually raised by the line manager for civil servants.
 
 #### Slack account deactivation
 


### PR DESCRIPTION
Updated the Leavers Guide to:
- remove references to Google Workspace
- update the Service Now link to the Digital Leavers bundle
- Remove the reference to the MoJ VPN which has been replaced by the Palo Alto Alpha VPN