### PR TITLE
ci: add test publish runbooks

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -5,7 +5,6 @@ on:
     tags:
       - "dependencies"
 
-
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Purpose

- Adds a test pipeline for "publish runbooks"
- `github-pages-deploy-action` `dry-run` is set to true so it doesn't run
- Only triggers when the PR has a `dependencies` tag generated by dependabot