### PR TITLE
fix(workflow): install tar

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       #     cd runbooks; /scripts/deploy.sh false
       - name: Install rsync
         run: |
-          apk update && apk add rsync
+          apk update && apk add rsync tar
           which rsync
 
       - name: Configure Pages


### PR DESCRIPTION
---
name: Cloud Platform Pull Request
about: Create new pull request for this repository

---

## Purpose

<!-- Clearly describe the problem PR solves -->
fix pipeline error 
```
tar: unrecognized option: hard-dereference
  BusyBox v1.34.1 (2022-07-19 20:11:24 UTC) multi-call binary.
  
  Usage: tar c|x|t [-ZzJjahmvokO] [-f TARFILE] [-C DIR] [-T FILE] [-X FILE] [LONGOPT]... [FILE]...
  
  Create, extract, or list files from a tar file
  
  	c	Create
  	x	Extract
  	t	List
  	-f FILE	Name of TARFILE ('-' for stdin/out)
  	-C DIR	Change to DIR before operation
  	-v	Verbose
  	-O	Extract to stdout
  	-m	Don't restore mtime
  	-o	Don't restore user:group
  	-k	Don't replace existing files
  	-Z	(De)compress using compress
  	-z	(De)compress using gzip
  	-J	(De)compress using xz
  	-j	(De)compress using bzip2
  	--lzma	(De)compress using lzma
  	-a	(De)compress based on extension
  	-h	Follow symlinks
  	-T FILE	File with names to include
  	-X FILE	File with glob patterns to exclude
  	--exclude PATTERN	Glob pattern to exclude
  	--overwrite		Replace existing files
  	--strip-components NUM	NUM of leading components to strip
  	--no-recursion		Don't descend in directories
  	--numeric-owner		Use numeric user:group
  	--no-same-permissions	Don't restore access permissions
  Error: Process completed with exit code 1.
```

## Approach

<!-- Describe how this approach address the issue -->

The issue is that upload-pages-artifact@v4 uses --hard-dereference, which GNU tar supports, but the Alpine container only has BusyBox's tar. The fix is to install GNU tar in the container.

Adding tar to the apk add command installs GNU tar, which supports --hard-dereference. Alpine's apk add tar replaces the BusyBox tar applet with the full GNU implementation.
