### PR TITLE
docs: add runbook entry on rotating chainguard creds

### DIFF
--- a/source/manually-rotate-chainguard-secret.html.md.erb
+++ b/source/manually-rotate-chainguard-secret.html.md.erb
@@ -1,0 +1,45 @@
+---
+title: Manually Rotate Chainguard Secret
+weight: 8600
+last_reviewed_on: 2026-05-26
+review_in: 6 months
+---
+
+# Manually Rotate Chainguard Secret
+
+This process will be automated in the future but currently it's manual.
+
+## Overview of how we use the Chainguard image
+
+There is a flag in the ingress module that can be toggled to enable support for the Chainguard image:
+
+```
+enable_chainguard = true
+```
+
+This then tells the helm chart to use the following image pull secret:
+
+```
+%{ if enable_chainguard ~}
+imagePullSecrets:
+  - name: chainguard-credentials
+%{ endif ~}
+```
+
+The secret is populated from the following parameter store `/cloud-platform/infrastructure/account/chainguard_registry_credentials` when the default ingress namespace is created.
+
+## Rotate Chainguard Secret
+
+The Chainguard Secret is a docker login auth token which needs to be generated.
+
+1. Create a new access token via the Chainguard [console](https://console.chainguard.dev/org/justice.gov.uk/settings/access-tokens?authRefresh=done#/)
+
+2. Run the docker login command provided
+
+3. Copy the generated docker auth config to the parameter store and save
+
+4. Re-run the `infrastructure` pipelines to ensure the new docker credentials are applied to the kubernetes secrets
+
+5. Optional: rollout restart ingress controllers
+
+


### PR DESCRIPTION
## Purpose

- new runbook entry for rotating chainguard credentials
- relates to:
https://github.com/ministryofjustice/cloud-platform/issues/8125