### PR TITLE
allocating CIDR ranges for new business unit Central Digital

### DIFF
--- a/cidr-allocation.md
+++ b/cidr-allocation.md
@@ -22,11 +22,11 @@
 | BU-1 non-live | 10.195.48.0/20 | /20 | 4,096 | OCTO |
 | BU-2 non-live | 10.195.64.0/20 | /20 | 4,096 | HMPPS |
 | BU-3 non-live | 10.195.80.0/20 | /20 | 4,096 | LAA |
-| BU-4 non-live | 10.195.96.0/20 | /20 | 4,096 | HQ |
-| BU-5 non-live | 10.195.112.0/20 | /20 | 4,096 | HMCTS |
-| BU-6 non-live | 10.195.128.0/20 | /20 | 4,096 | CICA |
-| BU-7 non-live | 10.195.144.0/20 | /20 | 4,096 | OPG |
-| BU-8 non-live | 10.195.160.0/20 | /20 | 4,096 | Unassigned |
+| BU-4 non-live | 10.195.96.0/20 | /20 | 4,096 | CD (Central Digital) |
+| BU-5 non-live | 10.195.112.0/20 | /20 | 4,096 | HQ |
+| BU-6 non-live | 10.195.128.0/20 | /20 | 4,096 | HMCTS |
+| BU-7 non-live | 10.195.144.0/20 | /20 | 4,096 | CICA |
+| BU-8 non-live | 10.195.160.0/20 | /20 | 4,096 | OPG |
 | BU-9 non-live | 10.195.176.0/20 | /20 | 4,096 | Unassigned |
 | Free | 10.195.192.0/18 | /18 | 16,384 | Unassigned |
 
@@ -37,11 +37,11 @@
 | BU-1 live | 10.41.0.0/20 | /20 | 4,096 | OCTO |
 | BU-2 live | 10.41.16.0/20 | /20 | 4,096 | HMPPS |
 | BU-3 live | 10.41.32.0/20 | /20 | 4,096 | LAA |
-| BU-4 live | 10.41.48.0/20 | /20 | 4,096 | HQ |
-| BU-5 live | 10.41.64.0/20 | /20 | 4,096 | HMCTS |
-| BU-6 live | 10.41.80.0/20 | /20 | 4,096 | CICA |
-| BU-7 live | 10.41.96.0/20 | /20 | 4,096 | OPG |
-| BU-8 live | 10.41.112.0/20 | /20 | 4,096 | Unassigned |
+| BU-4 live | 10.41.48.0/20 | /20 | 4,096 | CD (Central Digital) |
+| BU-5 live | 10.41.64.0/20 | /20 | 4,096 | HQ |
+| BU-6 live | 10.41.80.0/20 | /20 | 4,096 | HMCTS |
+| BU-7 live | 10.41.96.0/20 | /20 | 4,096 | CICA |
+| BU-8 live | 10.41.112.0/20 | /20 | 4,096 | OPG |
 | BU-9 live | 10.41.128.0/20 | /20 | 4,096 | Unassigned |
 | BU-10 live | 10.41.144.0/20 | /20 | 4,096 | Unassigned |
 | Free | 10.41.160.0/19 | /19 | 8,192 | Unassigned |
@@ -60,11 +60,11 @@ Each EKS cluster receives a /16 from the RFC6598 range for pod IPs.
 | BU-1 non-live | 100.68.0.0/16 | 65,536 | OCTO |
 | BU-2 non-live | 100.69.0.0/16 | 65,536 | HMPPS |
 | BU-3 non-live | 100.70.0.0/16 | 65,536 | LAA |
-| BU-4 non-live | 100.71.0.0/16 | 65,536 | HQ |
-| BU-5 non-live | 100.72.0.0/16 | 65,536 | HMCTS |
-| BU-6 non-live | 100.73.0.0/16 | 65,536 | CICA |
-| BU-7 non-live | 100.74.0.0/16 | 65,536 | OPG |
-| BU-8 non-live | 100.75.0.0/16 | 65,536 | Unassigned |
+| BU-4 non-live | 100.71.0.0/16 | 65,536 | CD (Central Digital) |
+| BU-5 non-live | 100.72.0.0/16 | 65,536 | HQ |
+| BU-6 non-live | 100.73.0.0/16 | 65,536 | HMCTS |
+| BU-7 non-live | 100.74.0.0/16 | 65,536 | CICA |
+| BU-8 non-live | 100.75.0.0/16 | 65,536 | OPG |
 | BU-9 non-live | 100.76.0.0/16 | 65,536 | Unassigned |
 | Free | 100.77.0.0/16 | 65,536 | Unassigned |
 | Free | 100.78.0.0/16 | 65,536 | Unassigned |
@@ -72,11 +72,11 @@ Each EKS cluster receives a /16 from the RFC6598 range for pod IPs.
 | BU-1 live | 100.80.0.0/16 | 65,536 | OCTO |
 | BU-2 live | 100.81.0.0/16 | 65,536 | HMPPS |
 | BU-3 live | 100.82.0.0/16 | 65,536 | LAA |
-| BU-4 live | 100.83.0.0/16 | 65,536 | HQ |
-| BU-5 live | 100.84.0.0/16 | 65,536 | HMCTS |
-| BU-6 live | 100.85.0.0/16 | 65,536 | CICA |
-| BU-7 live | 100.86.0.0/16 | 65,536 | OPG |
-| BU-8 live | 100.87.0.0/16 | 65,536 | Unassigned |
+| BU-4 live | 100.83.0.0/16 | 65,536 | CD (Central Digital) |
+| BU-5 live | 100.84.0.0/16 | 65,536 | HQ |
+| BU-6 live | 100.85.0.0/16 | 65,536 | HMCTS |
+| BU-7 live | 100.86.0.0/16 | 65,536 | CICA |
+| BU-8 live | 100.87.0.0/16 | 65,536 | OPG |
 | BU-9 live | 100.88.0.0/16 | 65,536 | Unassigned |
 | BU-10 live | 100.89.0.0/16 | 65,536 | Unassigned |
 | Free | 100.90.0.0/15 | 131,072 | Unassigned |


### PR DESCRIPTION
This PR updates the cidr-allocation.md to allocate `BU-4` slot cidr ranges to Central Digital business unit in CP3.

Previously `BU-4` was preallocated to `HQ`, but this BU has not been provisioned yet, and have moved it down the allocation list.