### PR TITLE
docs(cp30): ArgoCD GitOps hub & spoke documentation

### DIFF
--- a/architecture-decision-record/README.md
+++ b/architecture-decision-record/README.md
@@ -6,6 +6,11 @@ Cloud Platform.
 To understand why we are recording decisions and how we are doing it, please
 see [ADR-000](000-Record-Architecture-Decisions.md)
 
+> **Container Platform 3.0 (CP30):** decisions for the EKS-based platform are
+> recorded separately, under [`cp30/`](cp30/), using an independent `ADR-NNN`
+> numbering sequence. The table of contents below covers the original Cloud
+> Platform (CP2) decisions.
+
 ## Table of contents
 
 - ✅ [0. Record Architecture Decisions](000-Record-Architecture-Decisions.md)

--- a/architecture-decision-record/cp30/ADR-002-argocd-gitops-fleet-management.md
+++ b/architecture-decision-record/cp30/ADR-002-argocd-gitops-fleet-management.md
@@ -1,0 +1,335 @@
+# ADR-002: GitOps Fleet Management — EKS Capability for Argo CD vs. Self-Managed Argo CD
+
+**Status:** Proposed  
+**Date:** 2026-05-07  
+**Decision Maker:** AWS ProServe / MoJ Principal Technical Architect  
+**Category:** Compute / Integration
+
+---
+
+## Context
+
+**Problem Statement:** The multi-cluster, multi-account architecture requires centralised GitOps deployment orchestration. The platform team cannot manually push deployments to 20+ private-endpoint EKS clusters in separate accounts. A hub-and-spoke Argo CD model is required to provide unified visibility and declarative state management.
+
+**Requirements:** FR-014 (GitOps deployment model), FR-010 (automated cluster provisioning), NFR-006 (multi-cluster), NFR-007 (private cluster endpoints), NFR-002 (GitHub Actions integration)
+
+**Constraints:**
+- Cluster API endpoints are private (NFR-007) — Argo CD must reach spoke clusters without public endpoint or complex network configuration
+- Cross-account access is required (spoke clusters in BU accounts, hub in management account)
+- No Lambda (NFR-003)
+- GitHub is the source control platform (NFR-002)
+- EKS Capability for Argo CD was GA in November 2025 — not available when the candidate baseline PDF was written
+
+---
+
+## Decision
+
+**We will use the EKS Capability for Argo CD on the hub cluster as the managed GitOps controller, with per-BU AppProject-based separation enforcing both environment and tenant isolation.**
+
+This provides AWS-managed HA, upgrades, and native cross-account private cluster connectivity via EKS ARN + Access Entries — without VPC peering or TGW routing between accounts. A single Argo CD Capability instance manages both live and non-live clusters across all BUs (EKS limits one Argo CD Capability per cluster). Isolation is enforced through a per-BU, per-environment AppProject model where each project's destination allowlist restricts deployments to a single cluster ARN.
+
+### AppProject Hierarchy
+
+The AppProject model provides three layers of isolation: environment separation (live vs. non-live), BU-to-BU isolation, and platform vs. workload separation.
+
+**Platform projects (2 total):**
+
+| AppProject | Destinations | Sources | Sync Policy | Purpose |
+|------------|-------------|---------|-------------|---------|
+| `platform-live` | All live cluster ARNs (platform namespaces only) | Platform infrastructure repos | Manual | Platform add-ons (Gatekeeper, ADOT, Fluent Bit, ExternalDNS, LBC) on live clusters |
+| `platform-nonlive` | All non-live cluster ARNs (platform namespaces only) | Platform infrastructure repos | Auto-sync | Same platform stack on non-live clusters |
+
+**BU workload projects (2 per BU = ~16-18 total):**
+
+| AppProject | Destinations | Sources | Sync Policy | Purpose |
+|------------|-------------|---------|-------------|---------|
+| `bu1-live` | BU1 live cluster ARN only, workload namespaces | `github.com/ministryofjustice/bu1-*` | Manual | BU1 application deployments to live |
+| `bu1-nonlive` | BU1 non-live cluster ARN only, workload namespaces | `github.com/ministryofjustice/bu1-*` | Auto-sync | BU1 application deployments to non-live |
+| `bu2-live` | BU2 live cluster ARN only | `github.com/ministryofjustice/bu2-*` | Manual | BU2 live deployments |
+| `bu2-nonlive` | BU2 non-live cluster ARN only | `github.com/ministryofjustice/bu2-*` | Auto-sync | BU2 non-live deployments |
+| ... | ... | ... | ... | Same pattern for all 8-9 BUs |
+
+**Total: ~20 AppProjects** (2 platform + 8-9 BUs × 2 environments)
+
+### BU Isolation Guardrails
+
+Each BU AppProject enforces:
+
+| Guardrail | Mechanism | Effect |
+|-----------|-----------|--------|
+| Cluster isolation | `spec.destinations` restricted to single cluster ARN | BU1 project cannot deploy to BU2's cluster |
+| Source isolation | `spec.sourceRepos` restricted to BU's repos | BU1 cannot reference BU2's manifests |
+| Privilege restriction | `spec.namespaceResourceWhitelist` | BU teams can only create workload resources (Deployment, Service, Ingress, ConfigMap, Secret, HPA) |
+| Escalation prevention | `spec.clusterResourceBlacklist` | BU teams cannot create ClusterRole, ClusterRoleBinding, Namespace, or CRDs |
+
+### Multi-Namespace Support Within a BU
+
+Each BU has multiple application teams, each with one or more namespaces within the BU's cluster. Argo CD uses a Git directory-based ApplicationSet to generate one Application per namespace:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: bu1-live-apps
+  namespace: argocd
+spec:
+  generators:
+    - git:
+        repoURL: https://github.com/ministryofjustice/bu1-deployments
+        revision: main
+        directories:
+          - path: "apps/*"
+  template:
+    metadata:
+      name: "bu1-live-{{path.basename}}"
+    spec:
+      project: bu1-live
+      source:
+        repoURL: https://github.com/ministryofjustice/bu1-deployments
+        targetRevision: main
+        path: "{{path}}"
+      destination:
+        server: "arn:aws:eks:eu-west-2:111111111111:cluster/bu1-live"
+        namespace: "{{path.basename}}"
+      syncPolicy:
+        automated: false  # Manual sync for live
+```
+
+Adding a new app = adding a directory to the BU's deployment repo. The ApplicationSet generates the Argo CD Application automatically.
+
+**Namespace isolation within a BU** is enforced by Kubernetes (not Argo CD AppProjects):
+- EKS Access Entries map team identity to namespace-scoped RoleBindings
+- Gatekeeper admission policies block cross-namespace resource creation
+- Git-level access control (CODEOWNERS, branch protection) prevents Team A from modifying Team B's manifests
+
+### Isolation Layers (Defence in Depth)
+
+```
+Layer 1: AWS Account boundary     BU1 live account ≠ BU2 live account (hard isolation)
+Layer 2: AppProject destinations  bu1-live can ONLY reach BU1's live cluster ARN
+Layer 3: AppProject sources       bu1-live can ONLY pull from BU1's repos
+Layer 4: Kubernetes RBAC          Team A can only modify resources in their namespace
+Layer 5: Gatekeeper admission     Blocks cross-namespace resource creation
+Layer 6: Git access control       CODEOWNERS prevents Team A editing Team B's manifests
+```
+
+### Onboarding a New BU
+
+When a new BU is onboarded (US-011), the following is automated via Terraform:
+1. Provision BU's live and non-live AWS accounts + EKS clusters
+2. Create two AppProjects (`buN-live`, `buN-nonlive`) with correct cluster ARN destinations and source repo restrictions
+3. Register new cluster secrets in the hub cluster
+4. Platform ApplicationSet (cluster generator) automatically deploys platform add-ons to new clusters
+5. BU-specific ApplicationSet created to generate per-namespace Applications from the BU's deployment repo
+
+No manual Argo CD configuration is required for new BUs.
+
+### EKS Capability Constraint
+
+**Hard limit:** EKS allows only one Argo CD Capability instance per cluster ([source](https://docs.aws.amazon.com/eks/latest/userguide/capabilities.html)). If a future security assessment requires that IAM credentials for live clusters are never co-located with credentials for non-live clusters on the same compute, the architecture can evolve to two hub clusters (one per environment tier). This is documented as an escalation path, not the baseline design.
+
+---
+
+## Research Conducted
+
+### Option A: EKS Capability for Argo CD ✓ SELECTED
+
+**Research Confidence:** High
+
+| Source | URL | Key Finding |
+|--------|-----|-------------|
+| AWS Deep Dive Blog | https://aws.amazon.com/blogs/containers/deep-dive-streamlining-gitops-with-amazon-eks-capability-for-argo-cd/ | AWS-managed; cross-account private cluster access native via EKS ARN |
+| EKS Capability User Guide | https://docs.aws.amazon.com/eks/latest/userguide/argocd.html | GA November 2025; all standard regions including eu-west-2 |
+| EKS Comparison Guide | https://docs.aws.amazon.com/eks/latest/userguide/argocd-comparison.html | Comparison with self-managed; trade-offs documented |
+| AWS What's New | https://aws.amazon.com/about-aws/whats-new/2025/11/amazon-eks-capabilities/ | GA announcement: EKS Capabilities (Argo CD, KRO, ACK) |
+
+**Capabilities Verified:**
+- Runs in AWS-managed infrastructure outside customer worker nodes — verified
+- Cross-account private cluster access via EKS Access Entries (no VPC peering) — verified
+- ApplicationSets supported — verified
+- AppProjects supported — verified
+- IAM Identity Center required for authentication — verified (constraint documented)
+- CodeConnections for GitHub integration — verified
+- eu-west-2 available — verified
+
+### Option B: Self-Managed Argo CD on Hub Cluster
+
+**Research Confidence:** High
+
+| Source | URL | Key Finding |
+|--------|-----|-------------|
+| Candidate Baseline PDF | using-amazon-eks-capabilities...pdf | Hub cluster pattern; self-managed Argo CD; Platform + Workloads project separation |
+| Argo CD Docs | https://argo-cd.readthedocs.io/ | HA requires 3-replica setup; manual upgrade lifecycle |
+| EKS Fleet Management Research | eks-fleet-management-research.md (§5.1) | Self-managed requires VPC peering or TGW for cross-account private cluster access |
+
+**Capabilities Verified:**
+- Full Argo CD AppProject flexibility (multi-namespace) — verified
+- Platform team manages upgrades, HA, SSO — confirmed (operational overhead)
+- Cross-account private endpoint access: requires VPC peering or TGW + IAM role chaining — confirmed (complex)
+- Flexible authentication (OIDC, LDAP, Dex) — verified
+
+---
+
+## Capability Mapping
+
+| Requirement | Option A (EKS Capability) | Evidence | Option B (Self-Managed) | Evidence |
+|-------------|--------------------------|----------|------------------------|----------|
+| FR-014: Centralised GitOps across private clusters | Native cross-account via EKS ARN + Access Entries | AWS Deep Dive Blog | Requires TGW/VPC peering + role chaining | EKS Fleet research §5.1 |
+| NFR-007: Private cluster endpoint support | Native — AWS manages connectivity | EKS User Guide | Complex — VPC peering or TGW required | Research §5.1 |
+| NFR-006: Multi-account fleet management | ApplicationSets per cluster; cluster secrets registered by ARN | AWS Blog | Same ApplicationSets; additional network config | Candidate baseline |
+| FR-009: Security baseline (AppProject guardrails) | AppProjects supported (single-namespace constraint) | EKS User Guide | Full AppProject flexibility, multi-namespace | Argo CD docs |
+| NFR-002: GitHub Actions integration | CodeConnections (GitHub App); no runner access to spokes | AWS Blog | Custom SSH/token secrets; runners need spoke access for CD | Research §5.4 |
+
+---
+
+## Unknowns and Assumptions
+
+| Item | Type | Impact | Mitigation |
+|------|------|--------|------------|
+| Single-namespace constraint for Argo CD CRs | Constraint | Medium — candidate baseline uses multi-namespace pattern | All Argo CD CRs in one namespace is sufficient for MoJ; AppProjects provide separation |
+| One Argo CD Capability per cluster (EKS hard limit) | Constraint | Medium — cannot run separate instances for live vs. non-live on same hub | AppProject destination allowlists enforce environment boundaries; escalation path: two hub clusters if security assessment requires credential isolation |
+| GitHub Actions integration with private hub cluster | Assumption | Medium — hub Argo CD API must be accessible | Self-hosted runners in management VPC reach hub Argo CD API; spoke clusters not accessed directly |
+| EKS Capability Argo CD pricing at scale | Unknown | Low-Medium — per Application pricing | Confirm with AWS account team; ~20-30 Applications per cluster × 22 clusters = budgetable |
+| AppProject misconfiguration risk | Risk | Medium — a misconfigured AppProject could allow cross-environment deployment | Terraform-managed AppProject definitions (not manually edited); PR review for AppProject changes; PoC validates guardrails |
+
+---
+
+## Counter-Argument Analysis
+
+### Q1: What specific evidence would make me choose the alternative instead?
+
+If MoJ's AppProject requirements specifically required multiple Argo CD namespaces (multi-namespace Argo CD instance), self-managed would be necessary. The EKS Capability single-namespace constraint limits some advanced multi-tenancy patterns. However, AppProjects with source-repo guardrails satisfy MoJ's separation requirement within the single-namespace model.
+
+### Q2: Is there a managed/integrated AWS service that does this better?
+
+EKS Capability for Argo CD IS the managed AWS service for this capability. It was specifically designed for the hub-and-spoke multi-account use case.
+
+### Q3: What am I NOT seeing about the alternative that might make it superior?
+
+Self-managed Argo CD provides full Argo CD feature parity without the single-namespace constraint and allows custom Dex-based authentication if IAM Identity Center is not the preferred authentication mechanism. If MoJ wanted to use a non-IAM Identity Center OIDC provider for Argo CD, self-managed would be required.
+
+---
+
+## Alternative Consideration Checklist
+
+- [x] Searched for managed/integrated AWS services for this capability domain
+- [x] Researched minimum 2 viable alternatives with equal depth
+- [x] Documented specific AWS documentation URLs for each alternative
+- [x] Created capability mapping with evidence sources
+- [x] Documented unknowns and assumptions
+- [x] Assigned research confidence level to each alternative
+- [x] Completed Counter-Argument analysis
+
+---
+
+## Alternatives Considered
+
+### Option B: Self-Managed Argo CD — REJECTED
+
+**Why Rejected:** Requires complex cross-account networking (VPC peering or TGW) to reach private spoke cluster endpoints. The platform team would own Argo CD upgrades, HA, and SSO configuration — significant operational overhead for a small team. EKS Capability eliminates this complexity at the cost of IAM Identity Center dependency, which is required anyway for other platform services.
+
+**Pros:** Full Argo CD feature flexibility; multi-namespace AppProject support; authentication flexibility
+**Cons:** VPC peering or TGW required per spoke account for private endpoints; platform team manages upgrades, HA, and SSO; additional operational burden for small team
+
+---
+
+## Rationale
+
+In the context of managing GitOps deployments to 20+ private-endpoint EKS clusters across multiple AWS accounts, facing the constraint that cluster API endpoints must be private (NFR-007) and operational overhead must be minimised for a small platform team, we decided for EKS Capability for Argo CD and rejected self-managed Argo CD, to achieve native cross-account private cluster connectivity without VPC peering and eliminate GitOps infrastructure management overhead, accepting the single-namespace constraint and IAM Identity Center dependency, because the operational complexity of self-managed Argo CD with cross-account private endpoint networking is disproportionate to the team's capacity and the managed capability directly solves the private endpoint connectivity problem.
+
+---
+
+## Consequences
+
+### Positive
+- No VPC peering or TGW route between hub and spoke accounts for GitOps traffic
+- AWS manages Argo CD HA, upgrades, and scaling
+- Native CodeConnections GitHub integration (no webhook credential management)
+- Private spoke cluster access from day one without network configuration
+- AppProject destination allowlists enforce live/non-live separation at the Argo CD level
+- Unified deployment visibility across all environments from a single control plane
+
+### Negative
+- IAM Identity Center required (creates dependency on Identity Center being operational)
+- Single-namespace constraint for Argo CD CRs (deviation from candidate baseline multi-namespace pattern)
+- Per-Application pricing (predictable but adds cost at scale)
+- Single Argo CD instance means a misconfigured AppProject could theoretically cross environment boundaries (mitigated by Terraform-managed definitions and PR review)
+- Cannot run separate Argo CD instances for live vs. non-live on the same hub cluster (EKS hard limit)
+
+### Neutral
+- Platform and Workloads AppProject separation still achievable within single namespace
+- ApplicationSets for fleet-level automation supported natively
+- Escalation path to two hub clusters documented if security assessment requires stronger isolation
+
+---
+
+## PoC Validation Approach (Updated — Iteration 3, 3 July 2026)
+
+The ArgoCD hub-and-spoke model will be validated using:
+- **Hub cluster:** Development cluster in the `cloud-platform-development` account
+- **Spoke cluster:** `container-platform-octo-nonlive` cluster
+
+This validates:
+1. Cross-account private cluster access via EKS Access Entries
+2. ApplicationSet generation from the environments repo (ADR-015)
+3. AppProject boundaries enforcing BU isolation
+4. Platform add-on deployment to spoke clusters
+
+The dev cluster is purpose-built for validation and can be destroyed/recreated via the `development-cluster-deploy.yml` GitHub Actions workflow in `cloud-platform-github-workflows`.
+
+---
+
+## Implementation Notes (US-015a — 5 July 2026)
+
+The following design refinements were made during implementation:
+
+### Spoke Access Model — Spoke-Driven Registration
+
+The hub cluster creates a `<cluster-name>-argocd-spoke-access` IAM role with a trust policy scoped to the EKS service and the hub cluster ARN. The hub does NOT maintain a list of spoke account IDs or cluster ARNs, and does NOT proactively grant `sts:AssumeRole` or `eks:DescribeCluster` to spoke accounts.
+
+Instead, spoke registration is entirely spoke-driven: when a spoke cluster is provisioned, it adds the hub's spoke access role ARN as an EKS Access Entry with `AmazonEKSClusterAdminPolicy`. This means:
+- The hub cannot reach any cluster it hasn't been granted access to
+- A random cluster cannot register itself — someone must deliberately add the hub role as an Access Entry on the spoke side (controlled via Terraform PRs)
+- No spoke account list to maintain on the hub
+
+### CodeConnections — Optional for Public Repos
+
+MoJ repositories are public. ArgoCD can pull manifests from public repos over HTTPS without authentication. CodeConnections is included as an optional enhancement (defaults to empty/disabled) for production use, providing:
+- Webhook-based notifications (immediate sync vs. polling)
+- Higher GitHub API rate limits (5,000/hr authenticated vs. 60/hr unauthenticated)
+- Commit status write-back
+
+CodeConnections is only required in the hub account.
+
+### IDC Instance Configuration
+
+The IAM Identity Center instance ARN is passed as a GitHub Actions secret (`ARGOCD_IDC_INSTANCE_ARN`) rather than discovered dynamically via a Terraform data source. The `aws_ssoadmin_instances` data source requires `sso:ListInstances` permission which is only available in the management account — the workflow role in `cloud-platform-development` does not have cross-account access to query this. The IDC instance ARN is static infrastructure that rarely changes.
+
+### Single vs. Dual Hub — Noted Risk
+
+The team identified a specific concern: with a single hub managing both live and non-live environments, platform engineers testing ArgoCD configuration changes (ApplicationSets, AppProjects, RBAC) could accidentally affect live clusters. While the AppProject destination allowlists and manual sync policy for live mitigate this, the mitigations are procedural (PR review) rather than structural.
+
+The escalation path to two hub clusters (one per environment tier) provides a structural guarantee of isolation. The implementation module supports either pattern via the `enable_argocd` toggle — applying it to two separate cluster workspaces creates two independent hubs. The infrastructure cost is minimal since the Capability runs in AWS-managed infrastructure.
+
+This remains a team decision and does not change the baseline architecture.
+
+### Hub Enablement Mechanism
+
+ArgoCD is enabled on a cluster via `TF_VAR_enable_argocd=true` passed at deploy time through the `development-cluster-deploy` workflow. The module uses `count = var.enable_argocd ? 1 : 0` — when disabled (default), zero ArgoCD resources are created. This allows the same generic cluster module to provision both hub and spoke clusters.
+
+---
+
+## Related Decisions
+
+- **Depends On:** ADR-001 (EKS multi-cluster), ADR-004 (IAM Identity Center)
+- **Influences:** ADR-003 (KRO/ACK), ADR-015 (Environments repo structure)
+- **Related:** ADR-007 (DNS per cluster)
+
+---
+
+## Research Sources
+
+1. AWS Deep Dive: EKS Capability for Argo CD — https://aws.amazon.com/blogs/containers/deep-dive-streamlining-gitops-with-amazon-eks-capability-for-argo-cd/
+2. EKS Argo CD User Guide — https://docs.aws.amazon.com/eks/latest/userguide/argocd.html
+3. EKS Argo CD Comparison — https://docs.aws.amazon.com/eks/latest/userguide/argocd-comparison.html
+4. AWS What's New: EKS Capabilities GA — https://aws.amazon.com/about-aws/whats-new/2025/11/amazon-eks-capabilities/

--- a/architecture-decision-record/cp30/ADR-002-argocd-gitops-fleet-management.md
+++ b/architecture-decision-record/cp30/ADR-002-argocd-gitops-fleet-management.md
@@ -1,7 +1,8 @@
 # ADR-002: GitOps Fleet Management — EKS Capability for Argo CD vs. Self-Managed Argo CD
 
-**Status:** Proposed  
+**Status:** Accepted  
 **Date:** 2026-05-07  
+**Updated:** 2026-08-27 — recorded the two-hub (one per environment tier) model as the baseline, superseding the earlier single-hub design.  
 **Decision Maker:** AWS ProServe / MoJ Principal Technical Architect  
 **Category:** Compute / Integration
 
@@ -24,9 +25,9 @@
 
 ## Decision
 
-**We will use the EKS Capability for Argo CD on the hub cluster as the managed GitOps controller, with per-BU AppProject-based separation enforcing both environment and tenant isolation.**
+**We will use the EKS Capability for Argo CD as the managed GitOps controller, deployed as two hubs — one per environment tier (non-live and live) — with per-BU AppProject-based separation enforcing tenant isolation within each tier.**
 
-This provides AWS-managed HA, upgrades, and native cross-account private cluster connectivity via EKS ARN + Access Entries — without VPC peering or TGW routing between accounts. A single Argo CD Capability instance manages both live and non-live clusters across all BUs (EKS limits one Argo CD Capability per cluster). Isolation is enforced through a per-BU, per-environment AppProject model where each project's destination allowlist restricts deployments to a single cluster ARN.
+This provides AWS-managed HA, upgrades, and native cross-account private cluster connectivity via EKS ARN + Access Entries — without VPC peering or TGW routing between accounts. Each hub runs a single Argo CD Capability instance (EKS limits one Argo CD Capability per cluster) and manages only the spokes in its own tier: the `cloud-platform-nonlive` hub manages non-live spokes, and the `cloud-platform-live` hub manages live spokes. Environment isolation is therefore structural — live and non-live credentials never co-reside on the same hub compute. Within each tier, a per-BU AppProject model provides tenant isolation, where each project's destination allowlist restricts deployments to a single cluster ARN.
 
 ### AppProject Hierarchy
 
@@ -126,7 +127,7 @@ No manual Argo CD configuration is required for new BUs.
 
 ### EKS Capability Constraint
 
-**Hard limit:** EKS allows only one Argo CD Capability instance per cluster ([source](https://docs.aws.amazon.com/eks/latest/userguide/capabilities.html)). If a future security assessment requires that IAM credentials for live clusters are never co-located with credentials for non-live clusters on the same compute, the architecture can evolve to two hub clusters (one per environment tier). This is documented as an escalation path, not the baseline design.
+**Hard limit:** EKS allows only one Argo CD Capability instance per cluster ([source](https://docs.aws.amazon.com/eks/latest/userguide/capabilities.html)). Because a single instance cannot keep live and non-live IAM credentials on separate compute, the platform runs two hubs — one per environment tier — rather than one hub spanning both. This gives each tier its own Argo CD Capability instance and guarantees that live and non-live credentials are never co-located. The two hubs are the baseline design (see Implementation Notes → "Two-Hub Model").
 
 ---
 
@@ -187,7 +188,7 @@ No manual Argo CD configuration is required for new BUs.
 | Item | Type | Impact | Mitigation |
 |------|------|--------|------------|
 | Single-namespace constraint for Argo CD CRs | Constraint | Medium — candidate baseline uses multi-namespace pattern | All Argo CD CRs in one namespace is sufficient for MoJ; AppProjects provide separation |
-| One Argo CD Capability per cluster (EKS hard limit) | Constraint | Medium — cannot run separate instances for live vs. non-live on same hub | AppProject destination allowlists enforce environment boundaries; escalation path: two hub clusters if security assessment requires credential isolation |
+| One Argo CD Capability per cluster (EKS hard limit) | Constraint | Low — resolved by the two-hub model | Two hubs (one per tier) each run their own Capability instance, so live and non-live credentials are structurally isolated; AppProject destination allowlists provide defence in depth within a tier |
 | GitHub Actions integration with private hub cluster | Assumption | Medium — hub Argo CD API must be accessible | Self-hosted runners in management VPC reach hub Argo CD API; spoke clusters not accessed directly |
 | EKS Capability Argo CD pricing at scale | Unknown | Low-Medium — per Application pricing | Confirm with AWS account team; ~20-30 Applications per cluster × 22 clusters = budgetable |
 | AppProject misconfiguration risk | Risk | Medium — a misconfigured AppProject could allow cross-environment deployment | Terraform-managed AppProject definitions (not manually edited); PR review for AppProject changes; PoC validates guardrails |
@@ -252,20 +253,20 @@ In the context of managing GitOps deployments to 20+ private-endpoint EKS cluste
 ### Negative
 - IAM Identity Center required (creates dependency on Identity Center being operational)
 - Single-namespace constraint for Argo CD CRs (deviation from candidate baseline multi-namespace pattern)
-- Per-Application pricing (predictable but adds cost at scale)
-- Single Argo CD instance means a misconfigured AppProject could theoretically cross environment boundaries (mitigated by Terraform-managed definitions and PR review)
-- Cannot run separate Argo CD instances for live vs. non-live on the same hub cluster (EKS hard limit)
+- Per-Application pricing, across two hubs (predictable but adds cost at scale)
+- Two hubs to operate and upgrade instead of one (marginal, since the Capability is AWS-managed)
+- Within a tier, a misconfigured AppProject could still cross BU boundaries (mitigated by Terraform-managed definitions and PR review); it cannot cross the live/non-live boundary because that is enforced by separate hubs
 
 ### Neutral
 - Platform and Workloads AppProject separation still achievable within single namespace
 - ApplicationSets for fleet-level automation supported natively
-- Escalation path to two hub clusters documented if security assessment requires stronger isolation
+- Live and non-live are structurally isolated by running one hub per tier (the two-hub model)
 
 ---
 
 ## PoC Validation Approach (Updated — Iteration 3, 3 July 2026)
 
-The ArgoCD hub-and-spoke model will be validated using:
+The ArgoCD hub-and-spoke model was validated using an ephemeral hub/spoke pair before the permanent per-tier hubs (`cloud-platform-nonlive`, `cloud-platform-live`) were provisioned:
 - **Hub cluster:** Development cluster in the `cloud-platform-development` account
 - **Spoke cluster:** `container-platform-octo-nonlive` cluster
 
@@ -305,13 +306,16 @@ CodeConnections is only required in the hub account.
 
 The IAM Identity Center instance ARN is passed as a GitHub Actions secret (`ARGOCD_IDC_INSTANCE_ARN`) rather than discovered dynamically via a Terraform data source. The `aws_ssoadmin_instances` data source requires `sso:ListInstances` permission which is only available in the management account — the workflow role in `cloud-platform-development` does not have cross-account access to query this. The IDC instance ARN is static infrastructure that rarely changes.
 
-### Single vs. Dual Hub — Noted Risk
+### Two-Hub Model (Decision — supersedes the earlier single-hub baseline)
 
-The team identified a specific concern: with a single hub managing both live and non-live environments, platform engineers testing ArgoCD configuration changes (ApplicationSets, AppProjects, RBAC) could accidentally affect live clusters. While the AppProject destination allowlists and manual sync policy for live mitigate this, the mitigations are procedural (PR review) rather than structural.
+The team originally considered a single hub managing both live and non-live environments. That raised a specific concern: platform engineers testing ArgoCD configuration changes (ApplicationSets, AppProjects, RBAC) could accidentally affect live clusters, and the mitigations (AppProject destination allowlists, manual sync for live) were procedural (PR review) rather than structural.
 
-The escalation path to two hub clusters (one per environment tier) provides a structural guarantee of isolation. The implementation module supports either pattern via the `enable_argocd` toggle — applying it to two separate cluster workspaces creates two independent hubs. The infrastructure cost is minimal since the Capability runs in AWS-managed infrastructure.
+**Decision:** the platform runs two hubs, one per environment tier, giving a structural guarantee of isolation. This is now the implemented baseline, not an escalation path.
 
-This remains a team decision and does not change the baseline architecture.
+- **`cloud-platform-nonlive`** — the non-live hub, in the `cloud-platform-nonlive` account. Registers only non-live spokes.
+- **`cloud-platform-live`** — the live hub, in the `cloud-platform-live` account. Registers only live spokes.
+
+Each spoke resolves its hub by tier and a hub only registers spokes in its own tier, so live and non-live credentials are never co-located on the same hub compute. The two hubs are declared in `local.argocd_hubs` (Terraform, `cluster/locals.tf`), and each spoke derives its tier hub's Argo CD Capability role ARN by convention — no per-spoke input is required. The infrastructure cost of the second hub is minimal since the Capability runs in AWS-managed infrastructure.
 
 ### Hub Enablement Mechanism
 

--- a/architecture-decision-record/cp30/ADR-018-deployment-model-flexibility-gitops-vs-push-cd.md
+++ b/architecture-decision-record/cp30/ADR-018-deployment-model-flexibility-gitops-vs-push-cd.md
@@ -1,0 +1,152 @@
+# ADR-018: Deployment Model Flexibility — GitOps as Default, Push-Based CD as Accommodation
+
+**Status:** Proposed
+**Date:** 2026-07-24
+**Decision Maker:** AWS ProServe / MoJ Principal Technical Architect
+**Category:** Integration / Compute
+
+---
+
+## Context
+
+**Problem Statement:** ADR-002 selected the EKS Capability for Argo CD as the platform's GitOps controller. Application engineering teams have raised a concern: adopting ArgoCD signals a move away from the push-based CI/CD pipelines they have already built and operate. The platform needs a position on whether GitOps is mandatory for all workloads, or whether teams can continue deploying with their existing pipelines.
+
+**Requirements:** FR-014 (GitOps deployment model), FR-009 (security baseline enforcement), NFR-006 (multi-cluster fleet), NFR-007 (private cluster endpoints), and the implicit requirement of tenant team autonomy and low migration friction.
+
+**Constraints:**
+- The platform is multi-tenant across BU accounts; namespace-level guardrails (PSA restricted, default-deny NetworkPolicy, Gatekeeper constraints) must apply regardless of how workloads are deployed.
+- Spoke cluster API endpoints are private (NFR-007). Any push-based pipeline needs a network and credential path to reach them.
+- The platform team is small; every supported deployment path carries an ongoing operational cost.
+- App teams have existing, working CI/CD investment that has organisational value.
+
+---
+
+## Decision
+
+**We will make GitOps via ArgoCD the default and recommended deployment model, while supporting push-based deployment of workloads as a documented accommodation. The platform mandates GitOps ownership only for the namespace security baseline, not for workload deployment.**
+
+The mandate boundary is drawn at the namespace baseline. The platform owns namespace creation, RBAC, NetworkPolicy, and quota via the `app-baseline` chart reconciled by ArgoCD (ADR-015). Within a provisioned namespace, teams choose how to deploy their workloads.
+
+Three workload deployment paths are supported:
+
+| Path | Namespace baseline | Workload deployment | Cluster credentials in team CI |
+|------|-------------------|---------------------|-------------------------------|
+| **A — GitOps monorepo (default)** | Platform via ArgoCD | ArgoCD from shared `container-platform-environments` repo | None |
+| **B — GitOps own-repo** | Platform via ArgoCD | ArgoCD from the team's own repo (ApplicationSet points at it) | None |
+| **C — Push to namespace** | Platform via ArgoCD | Team's existing pipeline (`helm`/`kubectl`) into the pre-provisioned namespace | Scoped, namespace-only |
+
+Path A is recommended. Path B suits teams that want GitOps but not the shared-monorepo workflow. Path C is the accommodation for teams with mature push pipelines they do not wish to replace.
+
+---
+
+## GitOps + ArgoCD vs Traditional Push CD
+
+A framing point that addresses the core concern: **GitOps replaces the CD half, not CI.** Teams keep their build, test, lint, scan, and image-publish pipelines. Only the final "apply to cluster" step changes — from a pipeline running `kubectl apply` (push) to ArgoCD reconciling the cluster to match Git (pull).
+
+### Advantages of GitOps/ArgoCD
+
+- **No cluster credentials in CI.** With the EKS-managed ArgoCD reaching spokes via EKS Access Entries, no BU pipeline holds a kubeconfig or cluster-admin credential. This removes a large credential-distribution attack surface across many tenant pipelines.
+- **Drift detection and self-heal.** ArgoCD continuously reconciles desired vs live state; manual cluster edits are reverted. Push CD only knows state at deploy time.
+- **Git as single source of truth.** Every change to running state is a reviewed commit; rollback is `git revert`.
+- **Fleet-scale consistency with guardrails.** One hub manages many spokes with per-BU AppProjects enforcing which repos, clusters, and resource kinds are permitted (ADR-002). Replicating those guardrails across N independent push pipelines is materially harder.
+
+### Costs of GitOps/ArgoCD
+
+- **New tool and mental model.** Pull-based reconciliation, sync waves, health/sync status, and app-of-apps carry a genuine learning curve. The engineers' concern is legitimate.
+- **Debugging indirection.** "I merged, why isn't it live?" now spans ArgoCD sync status, reposerver cache, and generator behaviour rather than one pipeline log.
+- **Two-repo workflow (Path A).** App code and deployment manifests live in separate repos. Teams used to an integrated single-repo deploy feel the split. Path B mitigates this.
+- **Imperative steps need patterns.** DB migrations, one-off jobs, and dynamic secret injection require sync hooks or External Secrets rather than an inline pipeline step.
+- **Less imperative release control.** "Deploy exactly now, in this order, with this manual gate" needs extra tooling compared to a scripted pipeline.
+
+### Honest summary
+
+For a platform team operating a multi-tenant fleet, GitOps is close to industry standard and the security and consistency benefits are strong. For an individual app team with a working, well-understood pipeline, the marginal benefit is smaller and the switching cost is front-loaded. The decision balances fleet-level operability against team-level autonomy, which is why the platform mandates only the baseline and leaves workload deployment to the team.
+
+---
+
+## Accommodating Teams That Will Not Adopt ArgoCD
+
+The critical architectural question is whether a non-ArgoCD team can still deploy to a private spoke cluster while the platform retains its guardrails. The answer is yes, via Path C.
+
+**How Path C works:**
+1. Platform provisions the namespace and baseline (RBAC, NetworkPolicy, quota) via ArgoCD — same as every other team.
+2. The team receives a namespace-scoped credential (EKS Access Entry mapped to a namespace RoleBinding, or IRSA) — not cluster admin.
+3. The team's existing pipeline deploys workloads into that namespace using their current `helm`/`kubectl` steps.
+
+**What Path C gives up:** cluster credentials return to the team's CI (the main security benefit of GitOps is lost for that tenant), and drift becomes the team's responsibility since ArgoCD does not reconcile their workloads.
+
+**Network path:** private spoke endpoints (NFR-007) mean a push pipeline needs connectivity. Options are self-hosted runners in a VPC with a route to the cluster, or EKS API access via a bastion/relay. This is an operational prerequisite the team must accept for Path C.
+
+**What cannot be accommodated regardless of path:** the namespace security baseline (PSA restricted, default-deny NetworkPolicy, Gatekeeper constraints) is enforced at the Kubernetes admission layer, not by ArgoCD. A push pipeline is subject to the same admission control as a GitOps sync. Teams needing privileged workloads or baseline exemptions are having a platform-policy conversation, not a CI/CD one.
+
+---
+
+## Alternatives Considered
+
+### Option 1: Mandate GitOps for all workloads — REJECTED
+
+**Why Rejected:** Forces every team to rebuild working CD pipelines with no migration path, maximising switching cost and organisational friction for marginal benefit to teams that already deploy reliably. Risks adoption resistance that could stall the wider platform migration.
+
+**Pros:** Uniform operating model; every workload gets drift detection and no cluster credentials in CI; simplest for the platform team to reason about.
+**Cons:** High friction for teams with mature pipelines; ignores existing CD investment; adoption risk.
+
+### Option 2: No deployment standard (teams do whatever) — REJECTED
+
+**Why Rejected:** Without platform ownership of the namespace baseline, multi-tenant guardrails become inconsistent and unenforceable at fleet scale. Loses the central value of the hub/spoke model.
+
+**Pros:** Maximum team autonomy; zero migration friction.
+**Cons:** No consistent guardrail enforcement; no fleet-level visibility; undermines the rationale for a managed platform.
+
+---
+
+## Rationale
+
+In the context of onboarding application teams with established push-based CI/CD onto a multi-tenant EKS fleet, facing the constraint that namespace-level security guardrails must hold for every tenant while team autonomy and low migration friction are valued, we decided to mandate GitOps only for the namespace baseline and offer three workload deployment paths (GitOps monorepo, GitOps own-repo, push-to-namespace), and rejected both a full GitOps mandate and a no-standard free-for-all, to achieve consistent fleet guardrails without forcing teams to abandon working pipelines, accepting that push-based tenants reintroduce cluster credentials into their CI and own their own drift, because the guardrails that justify the platform are enforced at the admission layer independent of deployment mechanism, so deployment choice can be delegated safely to teams.
+
+---
+
+## Consequences
+
+### Positive
+- Teams with mature push pipelines can onboard without rebuilding CD.
+- Namespace security baseline is enforced uniformly regardless of deployment path.
+- GitOps remains the recommended path, so most teams still gain drift detection and credential-free CI.
+- Reduces adoption resistance and de-risks the wider migration.
+
+### Negative
+- The platform team supports more than one deployment path, increasing documentation and support surface.
+- Path C tenants reintroduce scoped cluster credentials into their CI and lose ArgoCD drift protection.
+- Path C requires a network path to private spoke endpoints, which each such team must provision and maintain.
+- Mixed models make fleet-wide "what is deployed where" harder to answer for push-based tenants.
+
+### Neutral
+- The `enable_argocd` and per-team ApplicationSet mechanisms already support Paths A and B with no new platform code.
+- Path C requires a documented namespace-scoped access pattern (EKS Access Entry or IRSA) and runner connectivity guidance.
+
+---
+
+## Unknowns and Assumptions
+
+| Item | Type | Impact | Mitigation |
+|------|------|--------|------------|
+| Number of teams expected to choose Path C | Unknown | Medium — drives support cost | Survey app teams during onboarding; revisit if Path C demand is high |
+| Namespace-scoped credential pattern for Path C | Assumption | Medium | Validate EKS Access Entry namespace-scope + RoleBinding in a PoC before offering Path C |
+| Private-endpoint reachability from team runners | Assumption | Medium | Document supported runner/relay patterns; confirm with a Path C pilot team |
+| Long-term drift on Path C namespaces | Risk | Low-Medium | Periodic platform audit of push-managed namespaces against baseline |
+
+---
+
+## Related Decisions
+
+- **Depends On:** ADR-002 (ArgoCD GitOps fleet management), ADR-015 (Environments repo structure)
+- **Related:** ADR-001 (EKS multi-cluster), ADR-004 (IAM Identity Center), ADR-009 (NetworkPolicy)
+
+---
+
+## Research Sources
+
+1. ADR-002: GitOps Fleet Management — EKS Capability for Argo CD
+2. ADR-015: Environments Repo Structure
+3. Argo CD Documentation — https://argo-cd.readthedocs.io/
+4. AWS Deep Dive: EKS Capability for Argo CD — https://aws.amazon.com/blogs/containers/deep-dive-streamlining-gitops-with-amazon-eks-capability-for-argo-cd/
+5. OpenGitOps Principles — https://opengitops.dev/

--- a/architecture-decision-record/cp30/ADR-018-deployment-model-flexibility-gitops-vs-push-cd.md
+++ b/architecture-decision-record/cp30/ADR-018-deployment-model-flexibility-gitops-vs-push-cd.md
@@ -1,7 +1,8 @@
-# ADR-018: Deployment Model Flexibility — GitOps as Default, Push-Based CD as Accommodation
+# ADR-018: Deployment Model — GitOps Monorepo Mandated as the Target, Push-Based CD as a Transitional Exception
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-07-24
+**Updated:** 2026-08-27 — GitOps via ArgoCD from the shared monorepo (Path A) is now the mandated target deployment model. GitOps from per-team repos (Path B) is documented for potential future consideration but is not part of the current decision, owing to drift and per-repo operational overhead concerns. Push-based CD (Path C) is retained only as a time-boxed migration exception. To be revisited if teams face strong, well-evidenced opposition.
 **Decision Maker:** AWS ProServe / MoJ Principal Technical Architect
 **Category:** Integration / Compute
 
@@ -23,19 +24,19 @@
 
 ## Decision
 
-**We will make GitOps via ArgoCD the default and recommended deployment model, while supporting push-based deployment of workloads as a documented accommodation. The platform mandates GitOps ownership only for the namespace security baseline, not for workload deployment.**
+**We will mandate GitOps via ArgoCD from the shared monorepo (Path A) as the target deployment model for all workloads. The platform owns the namespace security baseline via ArgoCD in every case, and GitOps from the monorepo is the expected mechanism for workload deployment. Per-team GitOps repos (Path B) are documented for potential future consideration only. Push-based deployment (Path C) is supported only as a time-boxed migration exception for teams with existing pipelines, not as a permanent co-equal option.**
 
-The mandate boundary is drawn at the namespace baseline. The platform owns namespace creation, RBAC, NetworkPolicy, and quota via the `app-baseline` chart reconciled by ArgoCD (ADR-015). Within a provisioned namespace, teams choose how to deploy their workloads.
+The platform owns namespace creation, RBAC, NetworkPolicy, and quota via the `app-baseline` chart reconciled by ArgoCD (ADR-015). The target state is that workloads are also deployed through ArgoCD from the shared `container-platform-environments` monorepo. A team may deploy with its own push pipeline only during an agreed migration window, under the exception process below.
 
-Three workload deployment paths are supported:
+Deployment paths:
 
-| Path | Namespace baseline | Workload deployment | Cluster credentials in team CI |
-|------|-------------------|---------------------|-------------------------------|
-| **A — GitOps monorepo (default)** | Platform via ArgoCD | ArgoCD from shared `container-platform-environments` repo | None |
-| **B — GitOps own-repo** | Platform via ArgoCD | ArgoCD from the team's own repo (ApplicationSet points at it) | None |
-| **C — Push to namespace** | Platform via ArgoCD | Team's existing pipeline (`helm`/`kubectl`) into the pre-provisioned namespace | Scoped, namespace-only |
+| Path | Namespace baseline | Workload deployment | Cluster credentials in team CI | Status |
+|------|-------------------|---------------------|-------------------------------|--------|
+| **A — GitOps monorepo** | Platform via ArgoCD | ArgoCD from shared `container-platform-environments` repo | None | Target (current decision) |
+| **B — GitOps own-repo** | Platform via ArgoCD | ArgoCD from the team's own repo (ApplicationSet points at it) | None | Documented for future consideration; not adopted |
+| **C — Push to namespace** | Platform via ArgoCD | Team's existing pipeline (`helm`/`kubectl`) into the pre-provisioned namespace | Scoped, namespace-only | Transitional exception |
 
-Path A is recommended. Path B suits teams that want GitOps but not the shared-monorepo workflow. Path C is the accommodation for teams with mature push pipelines they do not wish to replace.
+Path A is the decision: GitOps from the shared monorepo. Path B (per-team repos) is not adopted now — it risks configuration drift across many repos and adds per-repo operational overhead for a small platform team — but is documented below so it can be reconsidered later if there is a clear need. Path C is a transitional exception with a migration expectation, not a free choice a team can settle on indefinitely.
 
 ---
 
@@ -54,41 +55,48 @@ A framing point that addresses the core concern: **GitOps replaces the CD half, 
 
 - **New tool and mental model.** Pull-based reconciliation, sync waves, health/sync status, and app-of-apps carry a genuine learning curve. The engineers' concern is legitimate.
 - **Debugging indirection.** "I merged, why isn't it live?" now spans ArgoCD sync status, reposerver cache, and generator behaviour rather than one pipeline log.
-- **Two-repo workflow (Path A).** App code and deployment manifests live in separate repos. Teams used to an integrated single-repo deploy feel the split. Path B mitigates this.
+- **Two-repo workflow (Path A).** App code and deployment manifests live in separate repos. Teams used to an integrated single-repo deploy feel the split. Path B (per-team repos) could reduce this friction and is noted as a possible future option, but is not adopted now.
 - **Imperative steps need patterns.** DB migrations, one-off jobs, and dynamic secret injection require sync hooks or External Secrets rather than an inline pipeline step.
 - **Less imperative release control.** "Deploy exactly now, in this order, with this manual gate" needs extra tooling compared to a scripted pipeline.
 
-### Honest summary
+### Summary
 
-For a platform team operating a multi-tenant fleet, GitOps is close to industry standard and the security and consistency benefits are strong. For an individual app team with a working, well-understood pipeline, the marginal benefit is smaller and the switching cost is front-loaded. The decision balances fleet-level operability against team-level autonomy, which is why the platform mandates only the baseline and leaves workload deployment to the team.
+For a platform team operating a multi-tenant fleet, GitOps is the industry standard and the security and consistency benefits are strong. For an individual app team with a working, well-understood pipeline, the marginal benefit is smaller and the switching cost is front-loaded. This cost is a one-off migration expense rather than a reason to run two deployment models permanently: a single, uniform target keeps fleet-level operability simple for a small platform team. GitOps is therefore the mandated target, and the push-based path exists to smooth the transition, not to be a standing alternative.
 
 ---
 
-## Accommodating Teams That Will Not Adopt ArgoCD
+## Transitional Push-Based Deployment (Path C — Exception)
 
-The critical architectural question is whether a non-ArgoCD team can still deploy to a private spoke cluster while the platform retains its guardrails. The answer is yes, via Path C.
+GitOps is the target, but a team migrating from an established push pipeline may need time to get there. Path C exists for that transition. It is an exception, granted per team for a bounded period, not a permanent operating mode.
 
-**How Path C works:**
+**Exception process:**
+1. The team requests a Path C exception from the platform team, with a migration intent to Path A or B.
+2. The platform team agrees a time-boxed window and records the exception (owning team, reason, target GitOps path, review date).
+3. The exception is reviewed at the agreed date; it is renewed only if migration is genuinely blocked, otherwise the team is expected to be on GitOps.
+
+**How Path C works during the window:**
 1. Platform provisions the namespace and baseline (RBAC, NetworkPolicy, quota) via ArgoCD — same as every other team.
 2. The team receives a namespace-scoped credential (EKS Access Entry mapped to a namespace RoleBinding, or IRSA) — not cluster admin.
 3. The team's existing pipeline deploys workloads into that namespace using their current `helm`/`kubectl` steps.
 
-**What Path C gives up:** cluster credentials return to the team's CI (the main security benefit of GitOps is lost for that tenant), and drift becomes the team's responsibility since ArgoCD does not reconcile their workloads.
+**What Path C gives up:** cluster credentials return to the team's CI (the main security benefit of GitOps is lost for that tenant), and drift becomes the team's responsibility since ArgoCD does not reconcile their workloads. These are the reasons it is transitional rather than permanent.
 
-**Network path:** private spoke endpoints (NFR-007) mean a push pipeline needs connectivity. Options are self-hosted runners in a VPC with a route to the cluster, or EKS API access via a bastion/relay. This is an operational prerequisite the team must accept for Path C.
+**Network path:** private spoke endpoints (NFR-007) mean a push pipeline needs connectivity. Options are self-hosted runners in a VPC with a route to the cluster, or EKS API access via a bastion/relay. This is an operational prerequisite the team must accept for the duration of the exception.
 
-**What cannot be accommodated regardless of path:** the namespace security baseline (PSA restricted, default-deny NetworkPolicy, Gatekeeper constraints) is enforced at the Kubernetes admission layer, not by ArgoCD. A push pipeline is subject to the same admission control as a GitOps sync. Teams needing privileged workloads or baseline exemptions are having a platform-policy conversation, not a CI/CD one.
+**What is not negotiable regardless of path:** the namespace security baseline (PSA restricted, default-deny NetworkPolicy, Gatekeeper constraints) is enforced at the Kubernetes admission layer, not by ArgoCD. A push pipeline is subject to the same admission control as a GitOps sync. Teams needing privileged workloads or baseline exemptions are having a platform-policy conversation, not a CI/CD one.
 
 ---
 
 ## Alternatives Considered
 
-### Option 1: Mandate GitOps for all workloads — REJECTED
+### Option 1: GitOps as one of several co-equal, permanently-supported paths — REJECTED (superseded)
 
-**Why Rejected:** Forces every team to rebuild working CD pipelines with no migration path, maximising switching cost and organisational friction for marginal benefit to teams that already deploy reliably. Risks adoption resistance that could stall the wider platform migration.
+This was the earlier position in this ADR: GitOps recommended, but push-to-namespace offered as a standing accommodation a team could settle on indefinitely.
 
-**Pros:** Uniform operating model; every workload gets drift detection and no cluster credentials in CI; simplest for the platform team to reason about.
-**Cons:** High friction for teams with mature pipelines; ignores existing CD investment; adoption risk.
+**Why Rejected:** Running two deployment models permanently doubles the platform team's support and documentation surface and leaves fleet-wide "what is deployed where" partially unanswerable for push-based tenants. Without a clear target, teams have no signal to converge, so the split becomes permanent by default. The platform wants a single, clear target model; the switching cost for teams with mature pipelines is real but is a one-off migration expense, not a reason to carry two models forever.
+
+**Pros:** Lowest short-term friction; no team has to change anything.
+**Cons:** Permanent dual operating model; higher ongoing platform cost; weaker fleet consistency and visibility; no convergence signal.
 
 ### Option 2: No deployment standard (teams do whatever) — REJECTED
 
@@ -97,31 +105,48 @@ The critical architectural question is whether a non-ArgoCD team can still deplo
 **Pros:** Maximum team autonomy; zero migration friction.
 **Cons:** No consistent guardrail enforcement; no fleet-level visibility; undermines the rationale for a managed platform.
 
+### Option 3: GitOps from per-team repos (Path B) — DEFERRED (documented for future consideration)
+
+Under Path B, each team keeps its deployment manifests in its own repo and an ApplicationSet points ArgoCD at it, rather than everyone sharing the `container-platform-environments` monorepo. This keeps GitOps' security and drift-detection benefits while giving teams a single-repo feel.
+
+**Why Deferred (not adopted now):** many per-team repos multiply the surface where configuration can drift between what each repo declares and the platform's baseline expectations, and each additional repo and its ApplicationSet wiring is ongoing operational overhead for a small platform team. The monorepo keeps configuration and review in one place. Path B is documented here so it can be reconsidered if a clear need emerges (for example, teams with strong single-repo requirements or scaling limits on the monorepo).
+
+**Pros:** Single-repo developer experience while staying on GitOps; no cluster credentials in CI; keeps drift detection.
+**Cons:** Drift risk spread across many repos; per-repo ApplicationSet and review overhead; weaker central visibility than a monorepo.
+
+### Chosen: GitOps monorepo (Path A) mandated as the target, push-based (Path C) as a transitional exception
+
+GitOps from the shared monorepo (Path A) is the single target model. Per-team GitOps repos (Path B) are deferred and documented for future consideration. Push-based deployment (Path C) is retained only as a time-boxed migration exception so teams with existing pipelines are not forced to rebuild everything on day one, but the expectation is convergence on Path A. This gives the clear target the platform wants while keeping a humane migration path.
+
+**Revisit trigger:** the mandate will be reconsidered if teams face strong, well-evidenced opposition or genuine technical blockers to GitOps adoption; Path B may be revisited separately if a clear need for per-team repos emerges. Until then, the monorepo is the target and Path C is an exception, not a default.
+
 ---
 
 ## Rationale
 
-In the context of onboarding application teams with established push-based CI/CD onto a multi-tenant EKS fleet, facing the constraint that namespace-level security guardrails must hold for every tenant while team autonomy and low migration friction are valued, we decided to mandate GitOps only for the namespace baseline and offer three workload deployment paths (GitOps monorepo, GitOps own-repo, push-to-namespace), and rejected both a full GitOps mandate and a no-standard free-for-all, to achieve consistent fleet guardrails without forcing teams to abandon working pipelines, accepting that push-based tenants reintroduce cluster credentials into their CI and own their own drift, because the guardrails that justify the platform are enforced at the admission layer independent of deployment mechanism, so deployment choice can be delegated safely to teams.
+In the context of onboarding application teams with established push-based CI/CD onto a multi-tenant EKS fleet, facing the constraint that namespace-level security guardrails must hold for every tenant and that a small platform team needs a single tractable operating model, we decided to mandate GitOps via ArgoCD from the shared monorepo (Path A) as the target deployment model, to defer per-team GitOps repos (Path B) to potential future consideration on drift and per-repo overhead grounds, and to retain push-based deployment (Path C) only as a time-boxed migration exception, and rejected both keeping push-based CD as a permanent co-equal path and a no-standard free-for-all, to give teams a clear target while still offering a humane migration route, accepting that transitional Path C tenants reintroduce scoped cluster credentials into their CI and own their own drift until they migrate, because a single target model keeps fleet consistency, security, and support cost manageable, with the mandate to be revisited if teams face strong, well-evidenced opposition.
 
 ---
 
 ## Consequences
 
 ### Positive
-- Teams with mature push pipelines can onboard without rebuilding CD.
+- A single, clear target model (GitOps from the shared monorepo) that teams can plan towards, rather than an open-ended choice.
+- Keeping all deployment config in one monorepo bounds drift and review surface, versus spreading it across many per-team repos.
 - Namespace security baseline is enforced uniformly regardless of deployment path.
-- GitOps remains the recommended path, so most teams still gain drift detection and credential-free CI.
-- Reduces adoption resistance and de-risks the wider migration.
+- Most teams gain drift detection and credential-free CI; the fleet converges on one operating model over time.
+- Teams with mature push pipelines still get a migration route (Path C) rather than a day-one cliff edge.
 
 ### Negative
-- The platform team supports more than one deployment path, increasing documentation and support surface.
-- Path C tenants reintroduce scoped cluster credentials into their CI and lose ArgoCD drift protection.
-- Path C requires a network path to private spoke endpoints, which each such team must provision and maintain.
-- Mixed models make fleet-wide "what is deployed where" harder to answer for push-based tenants.
+- Teams with mature push pipelines face a one-off migration cost to reach the target model.
+- During transition the platform team supports two deployment paths, increasing documentation and support surface until Path C exceptions close out.
+- Path C tenants reintroduce scoped cluster credentials into their CI and lose ArgoCD drift protection for the duration of the exception.
+- Path C requires a network path to private spoke endpoints, which each such team must provision and maintain while on the exception.
+- Exceptions need tracking and periodic review, which is a small ongoing platform overhead.
 
 ### Neutral
-- The `enable_argocd` and per-team ApplicationSet mechanisms already support Paths A and B with no new platform code.
-- Path C requires a documented namespace-scoped access pattern (EKS Access Entry or IRSA) and runner connectivity guidance.
+- The ApplicationSet mechanism could support Path B (per-team repos) with little new platform code if it is adopted in future, but Path B is deferred for now.
+- Path C requires a documented namespace-scoped access pattern (EKS Access Entry or IRSA) and runner connectivity guidance for the transition period.
 
 ---
 
@@ -129,10 +154,11 @@ In the context of onboarding application teams with established push-based CI/CD
 
 | Item | Type | Impact | Mitigation |
 |------|------|--------|------------|
-| Number of teams expected to choose Path C | Unknown | Medium — drives support cost | Survey app teams during onboarding; revisit if Path C demand is high |
-| Namespace-scoped credential pattern for Path C | Assumption | Medium | Validate EKS Access Entry namespace-scope + RoleBinding in a PoC before offering Path C |
+| Number of teams needing a Path C exception, and for how long | Unknown | Medium — drives transitional support cost | Track exceptions with target migration dates; review at each window's end |
+| Strength of team opposition to the GitOps mandate | Unknown | Medium — could trigger a revisit of the mandate | Gather evidence during onboarding; escalate to decision maker if opposition is strong and well-evidenced |
+| Namespace-scoped credential pattern for Path C | Assumption | Medium | Validate EKS Access Entry namespace-scope + RoleBinding in a PoC before granting Path C exceptions |
 | Private-endpoint reachability from team runners | Assumption | Medium | Document supported runner/relay patterns; confirm with a Path C pilot team |
-| Long-term drift on Path C namespaces | Risk | Low-Medium | Periodic platform audit of push-managed namespaces against baseline |
+| Drift on Path C namespaces during the exception window | Risk | Low-Medium | Periodic platform audit of push-managed namespaces against baseline |
 
 ---
 

--- a/architecture-decision-record/cp30/README.md
+++ b/architecture-decision-record/cp30/README.md
@@ -1,0 +1,31 @@
+# Container Platform 3.0 Architecture Decisions
+
+This is the record of architectural decisions for **Container Platform 3.0
+(CP30)**, the EKS-based multi-cluster, multi-account platform.
+
+CP30 ADRs are kept separate from the original Cloud Platform (CP2) ADRs in the
+[parent directory](../). The two logs use independent numbering:
+
+- **CP2** ADRs are named `NNN-Title.md` (for example `047-use-karpenter-for-scaling.md`).
+- **CP30** ADRs are named `ADR-NNN-kebab-case.md` (for example `ADR-002-argocd-gitops-fleet-management.md`).
+
+The `ADR-NNN` numbers are the canonical CP30 identifiers and are referenced
+directly from the platform Terraform and user documentation, so they are stable
+and are not renumbered to avoid collisions with the CP2 sequence.
+
+These decisions were originally authored during the CP30 design phase and are
+being migrated into this repository as the permanent home. Additional CP30 ADRs
+will be added here over time.
+
+## Table of contents
+
+- 🤔 [ADR-002: GitOps Fleet Management — EKS Capability for Argo CD](ADR-002-argocd-gitops-fleet-management.md)
+- 🤔 [ADR-018: Deployment Model Flexibility — GitOps as Default, Push-Based CD as Accommodation](ADR-018-deployment-model-flexibility-gitops-vs-push-cd.md)
+
+### Statuses
+
+- Proposed: 🤔
+- Accepted: ✅
+- Rejected: ❌
+- Superseded: ⌛️
+- Amended: ♻️

--- a/architecture/container-platform/diagrams/argocd-hub-spoke.drawio.svg
+++ b/architecture/container-platform/diagrams/argocd-hub-spoke.drawio.svg
@@ -1,0 +1,197 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1200" height="940" viewBox="0 0 1200 940" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#37474f"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#2e7d32"/>
+    </marker>
+  </defs>
+  <style>
+    .title { font-size: 22px; font-weight: bold; fill: #102a43; }
+    .subtitle { font-size: 13px; fill: #486581; }
+    .acct { font-size: 13px; font-weight: bold; fill: #b1361e; }
+    .hub { font-size: 14px; font-weight: bold; fill: #0d3c78; }
+    .spoke { font-size: 13px; font-weight: bold; fill: #1b5e20; }
+    .lbl { font-size: 11px; fill: #37474f; }
+    .lblg { font-size: 11px; fill: #2e7d32; }
+    .small { font-size: 10.5px; fill: #52606d; }
+    .tier { font-size: 12px; font-weight: bold; fill: #334e68; }
+  </style>
+
+  <!-- Title -->
+  <text x="600" y="34" text-anchor="middle" class="title">Container Platform 3 — ArgoCD GitOps hub &amp; spoke</text>
+  <text x="600" y="54" text-anchor="middle" class="subtitle">Separate nonlive and live ArgoCD instances deploy to same-tier spoke clusters across AWS accounts</text>
+
+  <!-- GitOps source -->
+  <rect x="450" y="74" width="300" height="60" rx="8" fill="#263238" stroke="#102027" stroke-width="1.5"/>
+  <text x="600" y="99" text-anchor="middle" fill="#ffffff" font-size="13" font-weight="bold">GitHub (GitOps source of truth)</text>
+  <text x="600" y="118" text-anchor="middle" fill="#cfd8dc" font-size="11">ministryofjustice/container-platform-environments</text>
+
+  <!-- Hub account boundary -->
+  <rect x="60" y="170" width="1080" height="180" rx="10" fill="#eef4fb" stroke="#1565c0" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <text x="80" y="192" class="acct">Hub account (management plane)</text>
+
+  <!-- Nonlive hub -->
+  <rect x="120" y="210" width="440" height="120" rx="8" fill="#ffffff" stroke="#1565c0" stroke-width="1.5"/>
+  <text x="340" y="234" text-anchor="middle" class="hub">cloud-platform-nonlive</text>
+  <text x="340" y="253" text-anchor="middle" class="lbl">EKS cluster + EKS-managed ArgoCD capability</text>
+  <text x="340" y="271" text-anchor="middle" class="small">Runs in AWS-managed infrastructure (not on worker nodes)</text>
+  <text x="340" y="289" text-anchor="middle" class="small">Capability role: cloud-platform-nonlive-argocd-capability</text>
+  <text x="340" y="311" text-anchor="middle" fill="#1565c0" font-size="11" font-weight="bold">NONLIVE hub — manages nonlive spokes only</text>
+
+  <!-- Live hub -->
+  <rect x="640" y="210" width="440" height="120" rx="8" fill="#ffffff" stroke="#1565c0" stroke-width="1.5"/>
+  <text x="860" y="234" text-anchor="middle" class="hub">cloud-platform-live</text>
+  <text x="860" y="253" text-anchor="middle" class="lbl">EKS cluster + EKS-managed ArgoCD capability</text>
+  <text x="860" y="271" text-anchor="middle" class="small">Runs in AWS-managed infrastructure (not on worker nodes)</text>
+  <text x="860" y="289" text-anchor="middle" class="small">Capability role: cloud-platform-live-argocd-capability</text>
+  <text x="860" y="311" text-anchor="middle" fill="#1565c0" font-size="11" font-weight="bold">LIVE hub — manages live spokes only</text>
+
+  <!-- Git to hubs -->
+  <path d="M540,134 C440,160 380,180 340,208" fill="none" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <path d="M660,134 C760,160 820,180 860,208" fill="none" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="392" y="166" class="lbl">git pull via CodeConnections</text>
+  <text x="700" y="166" class="lbl">git pull via CodeConnections</text>
+
+  <!-- Deploy arrows hub -> spoke tier -->
+  <path d="M340,330 L340,430" fill="none" stroke="#2e7d32" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <path d="M860,330 L860,430" fill="none" stroke="#2e7d32" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <text x="352" y="368" class="lblg" font-weight="bold">deploy Applications</text>
+  <text x="352" y="384" class="lblg">hub's capability role uses each spoke's</text>
+  <text x="352" y="400" class="lblg">EKS access entry (argocd-hub RBAC)</text>
+  <text x="872" y="368" class="lblg" font-weight="bold">deploy Applications</text>
+  <text x="872" y="384" class="lblg">hub's capability role uses each spoke's</text>
+  <text x="872" y="400" class="lblg">EKS access entry (argocd-hub RBAC)</text>
+
+  <!-- Tier isolation marker -->
+  <path d="M560,270 L640,270" fill="none" stroke="#c62828" stroke-width="1.5" stroke-dasharray="4 4"/>
+  <line x1="588" y1="258" x2="612" y2="282" stroke="#c62828" stroke-width="2"/>
+  <line x1="612" y1="258" x2="588" y2="282" stroke="#c62828" stroke-width="2"/>
+  <text x="600" y="252" text-anchor="middle" fill="#c62828" font-size="10.5" font-weight="bold">tier isolation</text>
+
+  <!-- Nonlive spoke tier -->
+  <rect x="60" y="430" width="520" height="270" rx="10" fill="#f1f8f1" stroke="#2e7d32" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <text x="80" y="452" class="tier">Business-unit spoke accounts — NONLIVE tier</text>
+
+  <!-- Live spoke tier -->
+  <rect x="620" y="430" width="520" height="270" rx="10" fill="#f1f8f1" stroke="#2e7d32" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <text x="640" y="452" class="tier">Business-unit spoke accounts — LIVE tier</text>
+
+  <!-- Nonlive spoke: octo-nonlive -->
+  <rect x="78" y="466" width="158" height="216" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="157" y="487" text-anchor="middle" class="spoke">octo-nonlive</text>
+  <text x="157" y="505" text-anchor="middle" class="small">EKS spoke cluster</text>
+  <text x="157" y="520" text-anchor="middle" class="small">No ArgoCD runs here</text>
+  <rect x="92" y="530" width="130" height="66" rx="4" fill="#e8f5e9" stroke="#a5d6a7"/>
+  <text x="157" y="551" text-anchor="middle" class="small">team namespaces</text>
+  <text x="157" y="566" text-anchor="middle" class="small">+ workloads</text>
+  <text x="157" y="581" text-anchor="middle" class="small">(synced from Git)</text>
+  <text x="157" y="613" text-anchor="middle" class="small">Hub connects via an</text>
+  <text x="157" y="628" text-anchor="middle" class="small">EKS access entry mapped</text>
+  <text x="157" y="643" text-anchor="middle" class="small">to the argocd-hub</text>
+  <text x="157" y="658" text-anchor="middle" class="small">RBAC group</text>
+
+  <!-- Nonlive spoke: laa-nonlive -->
+  <rect x="243" y="466" width="158" height="216" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="322" y="487" text-anchor="middle" class="spoke">laa-nonlive</text>
+  <text x="322" y="505" text-anchor="middle" class="small">EKS spoke cluster</text>
+  <text x="322" y="520" text-anchor="middle" class="small">No ArgoCD runs here</text>
+  <rect x="257" y="530" width="130" height="66" rx="4" fill="#e8f5e9" stroke="#a5d6a7"/>
+  <text x="322" y="551" text-anchor="middle" class="small">team namespaces</text>
+  <text x="322" y="566" text-anchor="middle" class="small">+ workloads</text>
+  <text x="322" y="581" text-anchor="middle" class="small">(synced from Git)</text>
+  <text x="322" y="613" text-anchor="middle" class="small">Hub connects via an</text>
+  <text x="322" y="628" text-anchor="middle" class="small">EKS access entry mapped</text>
+  <text x="322" y="643" text-anchor="middle" class="small">to the argocd-hub</text>
+  <text x="322" y="658" text-anchor="middle" class="small">RBAC group</text>
+
+  <!-- Nonlive spoke: hmpps-nonlive -->
+  <rect x="408" y="466" width="158" height="216" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="487" y="487" text-anchor="middle" class="spoke">hmpps-nonlive</text>
+  <text x="487" y="505" text-anchor="middle" class="small">EKS spoke cluster</text>
+  <text x="487" y="520" text-anchor="middle" class="small">No ArgoCD runs here</text>
+  <rect x="422" y="530" width="130" height="66" rx="4" fill="#e8f5e9" stroke="#a5d6a7"/>
+  <text x="487" y="551" text-anchor="middle" class="small">team namespaces</text>
+  <text x="487" y="566" text-anchor="middle" class="small">+ workloads</text>
+  <text x="487" y="581" text-anchor="middle" class="small">(synced from Git)</text>
+  <text x="487" y="613" text-anchor="middle" class="small">Hub connects via an</text>
+  <text x="487" y="628" text-anchor="middle" class="small">EKS access entry mapped</text>
+  <text x="487" y="643" text-anchor="middle" class="small">to the argocd-hub</text>
+  <text x="487" y="658" text-anchor="middle" class="small">RBAC group</text>
+
+  <!-- Live spoke: octo-live -->
+  <rect x="638" y="466" width="158" height="216" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="717" y="487" text-anchor="middle" class="spoke">octo-live</text>
+  <text x="717" y="505" text-anchor="middle" class="small">EKS spoke cluster</text>
+  <text x="717" y="520" text-anchor="middle" class="small">No ArgoCD runs here</text>
+  <rect x="652" y="530" width="130" height="66" rx="4" fill="#e8f5e9" stroke="#a5d6a7"/>
+  <text x="717" y="551" text-anchor="middle" class="small">team namespaces</text>
+  <text x="717" y="566" text-anchor="middle" class="small">+ workloads</text>
+  <text x="717" y="581" text-anchor="middle" class="small">(synced from Git)</text>
+  <text x="717" y="613" text-anchor="middle" class="small">Hub connects via an</text>
+  <text x="717" y="628" text-anchor="middle" class="small">EKS access entry mapped</text>
+  <text x="717" y="643" text-anchor="middle" class="small">to the argocd-hub</text>
+  <text x="717" y="658" text-anchor="middle" class="small">RBAC group</text>
+
+  <!-- Live spoke: laa-live -->
+  <rect x="803" y="466" width="158" height="216" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="882" y="487" text-anchor="middle" class="spoke">laa-live</text>
+  <text x="882" y="505" text-anchor="middle" class="small">EKS spoke cluster</text>
+  <text x="882" y="520" text-anchor="middle" class="small">No ArgoCD runs here</text>
+  <rect x="817" y="530" width="130" height="66" rx="4" fill="#e8f5e9" stroke="#a5d6a7"/>
+  <text x="882" y="551" text-anchor="middle" class="small">team namespaces</text>
+  <text x="882" y="566" text-anchor="middle" class="small">+ workloads</text>
+  <text x="882" y="581" text-anchor="middle" class="small">(synced from Git)</text>
+  <text x="882" y="613" text-anchor="middle" class="small">Hub connects via an</text>
+  <text x="882" y="628" text-anchor="middle" class="small">EKS access entry mapped</text>
+  <text x="882" y="643" text-anchor="middle" class="small">to the argocd-hub</text>
+  <text x="882" y="658" text-anchor="middle" class="small">RBAC group</text>
+
+  <!-- Live spoke: hmpps-live -->
+  <rect x="968" y="466" width="158" height="216" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="1047" y="487" text-anchor="middle" class="spoke">hmpps-live</text>
+  <text x="1047" y="505" text-anchor="middle" class="small">EKS spoke cluster</text>
+  <text x="1047" y="520" text-anchor="middle" class="small">No ArgoCD runs here</text>
+  <rect x="982" y="530" width="130" height="66" rx="4" fill="#e8f5e9" stroke="#a5d6a7"/>
+  <text x="1047" y="551" text-anchor="middle" class="small">team namespaces</text>
+  <text x="1047" y="566" text-anchor="middle" class="small">+ workloads</text>
+  <text x="1047" y="581" text-anchor="middle" class="small">(synced from Git)</text>
+  <text x="1047" y="613" text-anchor="middle" class="small">Hub connects via an</text>
+  <text x="1047" y="628" text-anchor="middle" class="small">EKS access entry mapped</text>
+  <text x="1047" y="643" text-anchor="middle" class="small">to the argocd-hub</text>
+  <text x="1047" y="658" text-anchor="middle" class="small">RBAC group</text>
+
+  <!-- Dev account -->
+  <rect x="60" y="730" width="760" height="180" rx="10" fill="#fff8e1" stroke="#f9a825" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <text x="80" y="752" class="acct">Development account — ephemeral hub/spoke pairs</text>
+
+  <rect x="110" y="772" width="290" height="110" rx="8" fill="#ffffff" stroke="#1565c0" stroke-width="1.3"/>
+  <text x="255" y="798" text-anchor="middle" class="hub">cp-1708-2235-hub</text>
+  <text x="255" y="817" text-anchor="middle" class="small">enable_argocd = true</text>
+  <text x="255" y="834" text-anchor="middle" class="small">EKS-managed ArgoCD capability</text>
+  <text x="255" y="855" text-anchor="middle" class="small">role: cp-1708-2235-hub-argocd-capability</text>
+
+  <rect x="480" y="772" width="290" height="110" rx="8" fill="#ffffff" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="625" y="798" text-anchor="middle" class="spoke">cp-1708-2235-spoke</text>
+  <text x="625" y="817" text-anchor="middle" class="small">self-registers by "-hub"/"-spoke"</text>
+  <text x="625" y="834" text-anchor="middle" class="small">naming convention (same account)</text>
+  <text x="625" y="855" text-anchor="middle" class="small">access entry mapped to argocd-hub</text>
+
+  <path d="M400,827 L478,827" fill="none" stroke="#2e7d32" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <text x="439" y="818" text-anchor="middle" class="lblg">deploy</text>
+
+  <!-- Legend -->
+  <rect x="840" y="730" width="300" height="180" rx="10" fill="#ffffff" stroke="#90a4ae" stroke-width="1.2"/>
+  <text x="856" y="752" font-size="13" font-weight="bold" fill="#334e68">Key points</text>
+  <text x="856" y="774" class="small">• Two independent ArgoCD instances: nonlive</text>
+  <text x="866" y="789" class="small">and live, each on its own hub cluster.</text>
+  <text x="856" y="808" class="small">• Hub authenticates to spokes as its</text>
+  <text x="866" y="823" class="small">capability role via EKS access entries.</text>
+  <text x="856" y="842" class="small">• No VPC peering / TGW for GitOps traffic;</text>
+  <text x="866" y="857" class="small">cross-account access is native to EKS.</text>
+  <text x="856" y="876" class="small">• Spoke RBAC is least-privilege: cluster</text>
+  <text x="866" y="891" class="small">read + scoped workload write only.</text>
+  <text x="856" y="905" class="small">• A hub only registers spokes in its own tier.</text>
+
+</svg>

--- a/architecture/container-platform/diagrams/argocd-repo-structure.drawio.svg
+++ b/architecture/container-platform/diagrams/argocd-repo-structure.drawio.svg
@@ -1,0 +1,121 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1200" height="640" viewBox="0 0 1200 640" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arrow2" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#1565c0"/>
+    </marker>
+  </defs>
+  <style>
+    .title { font-size: 21px; font-weight: bold; fill: #102a43; }
+    .subtitle { font-size: 13px; fill: #486581; }
+    .panelh { font-size: 14px; font-weight: bold; fill: #0d3c78; }
+    .mono { font-family: "Courier New", monospace; font-size: 11px; fill: #2d3748; }
+    .monokey { font-family: "Courier New", monospace; font-size: 11px; font-weight: bold; fill: #1b5e20; }
+    .boxh { font-size: 12.5px; font-weight: bold; fill: #0d3c78; }
+    .small { font-size: 10.5px; fill: #52606d; }
+    .flow { font-size: 11px; font-weight: bold; fill: #1565c0; }
+  </style>
+
+  <text x="600" y="32" text-anchor="middle" class="title">GitOps repository structure — what good looks like</text>
+  <text x="600" y="52" text-anchor="middle" class="subtitle">How a product in container-platform-environments maps to ArgoCD ApplicationSets and to resources on a spoke cluster</text>
+
+  <!-- Panel A: repo -->
+  <rect x="30" y="74" width="400" height="548" rx="10" fill="#f7f9fc" stroke="#90a4ae" stroke-width="1.3"/>
+  <text x="45" y="96" class="panelh">1. Source repo (container-platform-environments)</text>
+
+  <text x="45" y="120" class="mono">container-platform-environments/</text>
+  <text x="45" y="135" class="mono">├─ charts/</text>
+  <text x="45" y="150" class="monokey">│  └─ app-baseline/         (baseline chart)</text>
+  <text x="45" y="165" class="mono">│     └─ templates/</text>
+  <text x="45" y="180" class="mono">│        ├─ namespace.yaml</text>
+  <text x="45" y="195" class="mono">│        ├─ rolebinding.yaml</text>
+  <text x="45" y="210" class="mono">│        └─ networkpolicy.yaml</text>
+  <text x="45" y="225" class="mono">└─ namespaces/</text>
+  <text x="45" y="240" class="mono">   └─ octo/                 (business unit)</text>
+  <text x="45" y="255" class="mono">      └─ helloworld/         (product)</text>
+  <text x="45" y="270" class="monokey">         ├─ product.yaml     (envs + access)</text>
+  <text x="45" y="285" class="mono">         ├─ helloworld-api/   (service)</text>
+  <text x="45" y="300" class="mono">         │  └─ deployment/</text>
+  <text x="45" y="315" class="mono">         │     ├─ Chart.yaml</text>
+  <text x="45" y="330" class="mono">         │     ├─ templates/</text>
+  <text x="45" y="345" class="mono">         │     │  ├─ deployment.yaml</text>
+  <text x="45" y="360" class="mono">         │     │  ├─ service.yaml</text>
+  <text x="45" y="375" class="mono">         │     │  └─ httproute.yaml</text>
+  <text x="45" y="390" class="monokey">         │     └─ values/</text>
+  <text x="45" y="405" class="monokey">         │        ├─ nonlive/</text>
+  <text x="45" y="420" class="mono">         │        │  ├─ dev.yaml</text>
+  <text x="45" y="435" class="mono">         │        │  └─ staging.yaml</text>
+  <text x="45" y="450" class="monokey">         │        └─ live/</text>
+  <text x="45" y="465" class="mono">         │           └─ prod.yaml</text>
+  <text x="45" y="480" class="mono">         └─ helloworld-frontend/ (service)</text>
+  <text x="45" y="495" class="mono">            └─ deployment/  (same shape)</text>
+  <text x="45" y="524" class="small">Every business unit and product follows this</text>
+  <text x="45" y="539" class="small">same layout. Highlighted paths drive the two</text>
+  <text x="45" y="554" class="small">ApplicationSets on the right.</text>
+
+  <!-- Panel B: hub ArgoCD -->
+  <rect x="455" y="74" width="340" height="548" rx="10" fill="#eef4fb" stroke="#1565c0" stroke-width="1.3"/>
+  <text x="470" y="96" class="panelh">2. Hub ArgoCD (per business unit)</text>
+
+  <rect x="470" y="112" width="310" height="150" rx="6" fill="#ffffff" stroke="#1565c0" stroke-width="1.2"/>
+  <text x="480" y="133" class="boxh">Baseline ApplicationSet</text>
+  <text x="480" y="152" class="small">generator: git-file-generator</text>
+  <text x="480" y="169" class="small">reads: namespaces/&lt;bu&gt;/*/product.yaml</text>
+  <text x="480" y="186" class="small">renders chart: charts/app-baseline</text>
+  <text x="480" y="207" class="small">creates, per environment:</text>
+  <text x="480" y="224" class="small">• Namespace</text>
+  <text x="480" y="240" class="small">• RoleBinding (from access:)</text>
+  <text x="480" y="256" class="small">• default-deny NetworkPolicy</text>
+
+  <rect x="470" y="278" width="310" height="170" rx="6" fill="#ffffff" stroke="#1565c0" stroke-width="1.2"/>
+  <text x="480" y="299" class="boxh">Workload ApplicationSet</text>
+  <text x="480" y="318" class="small">generator: git-directory-generator</text>
+  <text x="480" y="335" class="small">reads each values file under</text>
+  <text x="480" y="351" class="small">&lt;product&gt;/&lt;service&gt;/deployment/values/&lt;tier&gt;/</text>
+  <text x="480" y="372" class="small">renders that service's deployment chart</text>
+  <text x="480" y="388" class="small">with the selected tier values file</text>
+  <text x="480" y="409" class="small">creates workload objects:</text>
+  <text x="480" y="426" class="small">• Deployment, Service</text>
+  <text x="480" y="442" class="small">• HTTPRoute, HPA, ConfigMap…</text>
+
+  <rect x="470" y="464" width="310" height="92" rx="6" fill="#ffffff" stroke="#1565c0" stroke-width="1.2"/>
+  <text x="480" y="485" class="boxh">AppProject (e.g. octo-nonlive)</text>
+  <text x="480" y="504" class="small">Scopes what those Applications may do:</text>
+  <text x="480" y="521" class="small">allowed source repo, and the destination</text>
+  <text x="480" y="537" class="small">cluster and namespaces they can deploy to.</text>
+
+  <!-- Panel C: spoke result -->
+  <rect x="820" y="74" width="350" height="548" rx="10" fill="#f1f8f1" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="835" y="96" class="panelh" fill="#1b5e20">3. Result on the spoke (octo-nonlive)</text>
+
+  <rect x="835" y="112" width="320" height="180" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.2"/>
+  <text x="845" y="133" class="boxh" fill="#1b5e20">namespace: helloworld-dev</text>
+  <text x="845" y="155" class="small">baseline (from product.yaml):</text>
+  <text x="845" y="172" class="small">• RoleBinding: cloud-platform → edit</text>
+  <text x="845" y="188" class="small">• default-deny NetworkPolicy</text>
+  <text x="845" y="213" class="small">workloads (from values/nonlive/dev.yaml):</text>
+  <text x="845" y="230" class="small">• helloworld-api: Deployment + Service</text>
+  <text x="845" y="246" class="small">• helloworld-frontend: Deployment + Service</text>
+  <text x="845" y="262" class="small">• HTTPRoute exposes the service</text>
+  <text x="845" y="281" class="small">Namespace isolated from other products.</text>
+
+  <rect x="835" y="308" width="320" height="92" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.2"/>
+  <text x="845" y="329" class="boxh" fill="#1b5e20">namespace: helloworld-staging</text>
+  <text x="845" y="350" class="small">Same baseline and workloads, rendered</text>
+  <text x="845" y="366" class="small">from values/nonlive/staging.yaml, in its</text>
+  <text x="845" y="382" class="small">own isolated namespace on the same spoke.</text>
+
+  <rect x="835" y="416" width="320" height="140" rx="6" fill="#ffffff" stroke="#90a4ae" stroke-width="1.1"/>
+  <text x="845" y="437" class="boxh">product.yaml maps environments to</text>
+  <text x="845" y="453" class="boxh">a cluster and namespace</text>
+  <text x="845" y="475" class="small">dev → octo-nonlive / helloworld-dev</text>
+  <text x="845" y="491" class="small">staging → octo-nonlive / helloworld-staging</text>
+  <text x="845" y="507" class="small">prod → octo-live / helloworld-prod</text>
+  <text x="845" y="531" class="small">The live tier (prod) is deployed by the</text>
+  <text x="845" y="546" class="small">separate LIVE hub, never the nonlive hub.</text>
+
+  <!-- Flow arrows between panels -->
+  <path d="M433,345 L452,345" fill="none" stroke="#1565c0" stroke-width="2" marker-end="url(#arrow2)"/>
+  <text x="442" y="345" text-anchor="middle" class="flow" transform="rotate(-90 442 345)">reads from Git</text>
+  <path d="M798,345 L817,345" fill="none" stroke="#1565c0" stroke-width="2" marker-end="url(#arrow2)"/>
+  <text x="807" y="345" text-anchor="middle" class="flow" transform="rotate(-90 807 345)">renders &amp; deploys</text>
+</svg>

--- a/source/cp30/gitops-argocd.html.md.erb
+++ b/source/cp30/gitops-argocd.html.md.erb
@@ -1,0 +1,570 @@
+---
+title: GitOps with ArgoCD
+weight: 12
+last_reviewed_on: 2026-08-20
+review_in: 6 months
+---
+
+# <%= current_page.data.title %>
+
+## Overview
+
+Container Platform 3 (CP3) deploys application and platform workloads with
+[Argo CD](https://argo-cd.readthedocs.io/) using a GitOps model. Git is the
+single source of truth: the desired state of every workload lives in a Git
+repository, and Argo CD continuously reconciles each target cluster so that
+what is running matches what is committed.
+
+CP3 runs Argo CD as an **EKS-managed capability**. The Argo CD control plane
+runs in AWS-managed infrastructure attached to the cluster, not as pods on the
+cluster's own worker nodes. Authentication for engineers is handled through AWS
+IAM Identity Center (SSO), and access to Git repositories goes through AWS
+CodeConnections.
+
+The platform uses a **hub and spoke** topology. A small number of hub clusters
+run Argo CD and deploy to a larger number of spoke clusters that host the
+actual workloads. There are two independent instances:
+
+- a **nonlive** hub that manages all nonlive spokes, and
+- a **live** hub that manages all live spokes.
+
+Keeping the two instances separate means a change to Argo CD (an upgrade, a new
+capability version, or a configuration change) can be proven against nonlive
+workloads before it reaches live workloads.
+
+> This page is a developer and platform-engineer guide to how the solution
+> works and how to operate it. The Terraform that implements it lives in
+> [modernisation-platform-environments](https://github.com/ministryofjustice/modernisation-platform-environments)
+> under `terraform/environments/cloud-platform`, and the design is recorded in
+> ADR-002 (GitOps Fleet Management) and ADR-018 (Deployment Model Flexibility).
+
+## Architecture
+
+![Multi-account ArgoCD hub and spoke architecture](../images/argocd-hub-spoke.drawio.svg)
+
+The diagram shows the full picture: the GitOps source repository, the two hub
+clusters in the hub account, the business-unit spoke clusters split by tier, and
+the ephemeral hub/spoke pairs used for development.
+
+### Hubs
+
+A **hub** is an EKS cluster that runs the Argo CD capability. Two permanent hubs
+live in the hub account:
+
+| Hub cluster | Tier | Manages |
+|-------------|------|---------|
+| `cloud-platform-nonlive` | nonlive | all nonlive spokes |
+| `cloud-platform-live` | live | all live spokes |
+
+Each hub gets a dedicated IAM role named `<cluster-name>-argocd-capability`
+(for example `cloud-platform-nonlive-argocd-capability`). This is the identity
+the EKS-managed Argo CD runs as. It is the role that reads Git through
+CodeConnections and the role that authenticates to spoke clusters.
+
+A cluster becomes a hub when its Terraform workspace is listed in
+`local.argocd_hubs`, or when it is deployed with `enable_argocd = true` (used
+for ephemeral development hubs). Hub clusters are tagged `argocd-role=hub`.
+
+### Spokes
+
+A **spoke** is an EKS cluster that receives workloads from a hub. Spokes do not
+run an Argo CD control plane of their own. Each business unit (OCTO, LAA, HMPPS, etc)
+has spoke clusters in its own AWS account, one per tier (nonlive and live).
+
+A spoke grants the hub access by creating a single EKS **access entry** for the
+hub's capability role and placing that role in the Kubernetes group
+`argocd-hub`. Scoped RBAC bound to that group is what authorises the hub (see
+[Security model](#security-model)).
+
+### How the hub reaches a spoke
+
+Cross-account access is native to EKS access entries, so **no VPC peering or
+Transit Gateway is needed for GitOps traffic**. The flow is:
+
+1. The EKS-managed Argo CD on the hub authenticates to the spoke's Kubernetes
+   API as the hub's capability role.
+2. The spoke's access entry maps that role into the `argocd-hub` group.
+3. Kubernetes RBAC bound to `argocd-hub` decides what the hub may read and write.
+
+On the hub, each spoke is registered with a minimal Kubernetes Secret labelled
+`argocd.argoproj.io/secret-type: cluster`. That Secret contains only the spoke's
+name and its cluster ARN (the `server` field). It deliberately carries no
+`roleARN`, no `awsAuthConfig`, and no bearer token, because the authentication
+is handled entirely by the IAM role and the spoke's EKS access entry.
+
+### Tier isolation
+
+A hub only ever registers spokes in its own tier. The nonlive hub derives its
+tier from its workspace and builds its spoke list from nonlive spokes only; the
+live hub does the same for live. A nonlive hub cannot register or deploy to a
+live spoke, and the reverse is also true. This boundary is enforced in
+Terraform, not by convention alone.
+
+### How workloads reach a spoke
+
+User workloads are defined as Helm values and manifests in the
+[container-platform-environments](https://github.com/ministryofjustice/container-platform-environments)
+monorepo, under a predictable path:
+
+```
+namespaces/<business-unit>/<product>/<service>/deployment/values/<tier>/<name>.yaml
+```
+
+On each hub, per-business-unit **ApplicationSets** watch that repository with Git
+generators. When a values file appears, the ApplicationSet renders an Argo CD
+**Application** from a template and points its destination at the correct spoke
+cluster and namespace. Argo CD then syncs the workload (Deployment, Service,
+ConfigMap, HTTPRoute, and so on) onto the spoke.
+
+A per-business-unit **AppProject** (for example `octo-nonlive`) scopes what
+those Applications are allowed to do: which source repositories they can pull
+from and which destination clusters and namespaces they can deploy to.
+
+A separate baseline ApplicationSet renders the `app-baseline` chart for each
+product. The baseline creates the namespace, a default-deny `NetworkPolicy`,
+and the per-namespace `RoleBinding`s that grant teams access to their own
+namespaces. The baseline runs so that a namespace and its guardrails exist
+before workloads land in it.
+
+### Repository structure: what good looks like
+
+The diagram below shows how one product maps from the repository, through the
+two ApplicationSets, to the resources that end up on a spoke. Every business
+unit and product follows the same layout, so this is the shape to copy when
+onboarding a new workload.
+
+![How a product maps from the repository to ApplicationSets to spoke resources](../images/argocd-repo-structure.drawio.svg)
+
+A product is described by a single `product.yaml` plus one directory per
+service:
+
+- **`product.yaml`** declares the product's environments and access. Each
+  environment maps a logical stage (`dev`, `staging`, `prod`) to a target
+  cluster and namespace, and the `access` block lists which GitHub team groups
+  get `view`, `edit`, or `admin` in those namespaces. Live environments should
+  default to `view` only, because deployments go through Argo CD rather than
+  direct cluster access.
+- **Each service** (for example `helloworld-api`) has a `deployment/` directory
+  containing its Helm chart (`Chart.yaml`, `templates/`) and a `values/` tree
+  split by tier: `values/nonlive/` (for example `dev.yaml`, `staging.yaml`) and
+  `values/live/` (for example `prod.yaml`).
+
+The two ApplicationSets read different parts of this layout:
+
+- The **baseline ApplicationSet** reads each `product.yaml` and renders the
+  shared `app-baseline` chart, creating the Namespace, `RoleBinding`s, and the
+  default-deny `NetworkPolicy` for every environment on the target cluster.
+- The **workload ApplicationSet** reads each values file under
+  `deployment/values/<tier>/` and renders that service's own chart with the
+  selected values, deploying the Deployment, Service, HTTPRoute, and related
+  objects into the mapped namespace.
+
+Because the tier lives in the path, the same service definition produces
+isolated dev and staging namespaces on the nonlive spoke, while the production
+values deploy to the live spoke through the separate live hub.
+
+## Key features
+
+- **EKS-managed control plane.** Argo CD runs as an EKS capability in
+  AWS-managed infrastructure. There are no Argo CD pods to run, patch, or scale
+  on worker nodes, and there is one Argo CD capability per cluster (an EKS
+  limit).
+- **Two independent instances.** Nonlive and live are fully separate hubs, so
+  platform changes are validated on nonlive before reaching live.
+- **Multi-account by design.** Hubs and spokes live in different AWS accounts.
+  The hub reaches each spoke through EKS access entries, with no cross-account
+  assume-role and no network peering for GitOps traffic.
+- **Declarative fleet management.** ApplicationSets generate Applications from
+  the Git monorepo, so onboarding a new workload is a Git change rather than a
+  manual Argo CD operation.
+- **SSO authentication.** Engineers authenticate to the Argo CD UI and API
+  through IAM Identity Center; access is mapped to SSO groups.
+- **Ephemeral test environments.** Development hub/spoke pairs can be created and
+  destroyed on demand, wired together by a naming convention.
+
+## Security model
+
+The security posture centres on **least privilege for the hub on each spoke**.
+
+The hub's capability role is registered on a spoke with an EKS access entry, but
+**no EKS access policy is attached**. `AmazonEKSClusterAdminPolicy` is
+equivalent to `system:masters`, which AWS documents as unsuitable for
+production. Instead, authorisation comes from two custom `ClusterRole`s bound to
+the `argocd-hub` group:
+
+| ClusterRole | Scope | Purpose |
+|-------------|-------|---------|
+| `argocd-hub-read-all` | `get`, `list`, `watch` on all resources | Resource discovery, health assessment, and drift detection |
+| `argocd-hub-deploy` | write on a fixed set of workload kinds | Creating and updating the resources Applications actually manage |
+
+`argocd-hub-deploy` grants write access to namespaces, core workload resources
+(ConfigMaps, Secrets, Services, ServiceAccounts, PVCs), workload controllers
+(Deployments, StatefulSets, DaemonSets, ReplicaSets, Jobs, CronJobs, HPAs, PDBs),
+Ingresses and NetworkPolicies, Gateway API routes (HTTPRoute, GRPCRoute,
+ListenerSet), and namespace-scoped RBAC (Roles and RoleBindings). It can `bind`
+only the built-in `view`, `edit`, and `admin` ClusterRoles.
+
+The hub is **deliberately not** granted the ability to write cluster-scoped RBAC
+(ClusterRoles or ClusterRoleBindings), install CustomResourceDefinitions, change
+admission webhooks, or touch nodes. A compromised hub therefore cannot escalate
+its own privileges on a spoke, install cluster-wide controllers, or tamper with
+admission control. This least-privilege boundary is guarded by regression tests
+in [container-platform-integration-tests](https://github.com/ministryofjustice/container-platform-integration-tests).
+
+Two more properties reinforce the model:
+
+- **Minimal registration Secret.** The cluster Secret on the hub holds only the
+  spoke name and cluster ARN. No credentials are stored in it, so there is
+  nothing sensitive to leak from the registration data itself.
+- **Tier isolation.** Because a hub only registers spokes in its own tier, a
+  nonlive hub has no access path to a live spoke.
+
+## Operational benefits
+
+- **Smaller blast radius.** Splitting nonlive and live limits the impact of an
+  Argo CD change or outage to a single tier.
+- **Less to operate.** The managed control plane removes the work of running
+  Argo CD itself, so the team focuses on Applications and policy rather than on
+  Argo CD availability.
+- **Auditable changes.** Every workload change is a Git commit, giving a review
+  trail and a straightforward rollback (revert the commit).
+- **Consistent onboarding.** New workloads and new business units follow the
+  same repository layout and the same ApplicationSet machinery.
+- **Fast, safe experimentation.** Ephemeral hub/spoke pairs let engineers test
+  changes end to end on real infrastructure and then tear it all down.
+
+## Runbooks
+
+These runbooks are for platform engineers operating the Argo CD solution. They
+assume you have an active AWS SSO session for the relevant account and, where
+noted, `kubectl` access to the target cluster.
+
+Set your profile and region before running `aws` or `kubectl`:
+
+```bash
+export AWS_PROFILE=<profile> AWS_REGION=eu-west-2
+aws eks update-kubeconfig --name <cluster-name>
+```
+
+You do not need local AWS credentials to run the GitHub Actions workflows; CI
+authenticates to AWS with its own OIDC role. You only need local credentials for
+your own `aws` and `kubectl` verification.
+
+#### Running the workflows with the GitHub CLI
+
+The runbooks below trigger GitHub Actions workflows from the command line using
+`gh`, the [official GitHub CLI](https://cli.github.com/). It lets you run
+workflows, open issues, and manage pull requests from a terminal instead of the
+browser. Install it with `brew install gh` (macOS) or follow the
+[installation guide](https://github.com/cli/cli#installation), then sign in once
+with `gh auth login`.
+
+The command used throughout is `gh workflow run`, which dispatches a workflow.
+Each `-f key=value` flag sets one of the workflow's inputs.
+
+> Prefer a browser? Every `gh workflow run` example here has an equivalent in
+> the GitHub Actions UI: open the workflow, choose **Run workflow**, and fill in
+> the same inputs. See [Create Development Cluster](create-development-cluster.html)
+> for the UI walkthrough.
+
+### Spin up an ephemeral hub and spoke pair
+
+Ephemeral clusters are created with the **Development Cluster Deployment**
+workflow in
+[cloud-platform-github-workflows](https://github.com/ministryofjustice/cloud-platform-github-workflows/actions/workflows/development-cluster-deploy.yml).
+All ephemeral clusters land in the development account.
+
+Pair a hub and spoke with a shared prefix and the suffixes `-hub` and `-spoke`,
+for example `cp-1708-2235-hub` and `cp-1708-2235-spoke`.
+
+1. **Deploy the hub** with Argo CD enabled:
+
+   ```bash
+   gh workflow run "Development Cluster Deployment" \
+     --repo ministryofjustice/cloud-platform-github-workflows \
+     --ref main \
+     -f cluster_action=deploy \
+     -f cluster_name=cp-1708-2235-hub \
+     -f branch_name=main \
+     -f enable_argocd=true
+   ```
+
+2. **Read the hub's capability role ARN.** It follows the convention
+   `arn:aws:iam::<dev-account-id>:role/<hub-name>-argocd-capability`, and the
+   deploy job also prints it in the workflow summary.
+
+3. **Deploy the spoke.** An ephemeral spoke whose name ends in `-spoke`
+   self-registers with its `-hub` partner in the same account. Passing it explicitly is a safe override:
+
+   ```bash
+   gh workflow run "Development Cluster Deployment" \
+     --repo ministryofjustice/cloud-platform-github-workflows \
+     --ref main \
+     -f cluster_action=deploy \
+     -f cluster_name=cp-1708-2235-spoke \
+     -f branch_name=main \
+     -f argocd_hub_capability_role_arn=arn:aws:iam::<dev-account-id>:role/cp-1708-2235-hub-argocd-capability
+   ```
+
+The hub side auto-creates the spoke's cluster registration Secret from the same
+naming convention, so no manual Secret is needed.
+
+> `branch_name` selects which version of the Terraform code deploys and is
+> truncated to 12 characters. Use `main` once your changes are merged. See
+> [Create Development Cluster](create-development-cluster.html) for the UI-based
+> equivalent.
+
+### Tear down an ephemeral hub and spoke pair
+
+Destroy the **spoke first, then the hub**. This removes the spoke's access entry
+before the hub that references it goes away.
+
+```bash
+# 1. Destroy the spoke
+gh workflow run "Development Cluster Deployment" \
+  --repo ministryofjustice/cloud-platform-github-workflows \
+  --ref main \
+  -f cluster_action=destroy \
+  -f cluster_name=cp-1708-2235-spoke \
+  -f branch_name=main
+
+# 2. Destroy the hub
+gh workflow run "Development Cluster Deployment" \
+  --repo ministryofjustice/cloud-platform-github-workflows \
+  --ref main \
+  -f cluster_action=destroy \
+  -f cluster_name=cp-1708-2235-hub \
+  -f branch_name=main
+```
+
+On a development hub, a pre-destroy cleanup step runs automatically before the
+cluster is removed. It deletes all Argo CD Applications and ApplicationSets to
+stop sync loops, deletes the Argo CD capability through the AWS API, removes
+finalizers from the `argocd` namespace, and then deletes that namespace. This
+cleanup prevents the cluster deletion from hanging on stuck resources.
+
+> Destroying a cluster while the Argo CD capability is still attached fails with
+> `ResourceInUseException: Cluster has capabilities attached`. Always destroy
+> through the workflow, which orders these steps correctly, rather than deleting
+> the cluster directly.
+
+### Onboard a permanent spoke
+
+Permanent spokes do not self-register. Adding one is a deliberate, reviewed
+change in
+[modernisation-platform-environments](https://github.com/ministryofjustice/modernisation-platform-environments):
+
+1. Add the spoke's workspace name to `argocd_registered_spokes` in the correct
+   tier block of `cluster/environment-configuration.tf`. The nonlive block for
+   the nonlive hub, the live block for the live hub.
+2. Raise a PR. The registration only takes effect when the spoke is a known
+   permanent environment and appears in the tier's allowlist.
+3. On apply, the spoke creates the `argocd-hub` access entry and RBAC, and the
+   hub creates the matching cluster registration Secret and AppProjects.
+
+Removing a spoke is the reverse: delete it from `argocd_registered_spokes` and
+apply.
+
+### Manage the hub-to-spoke RBAC
+
+The access the hub has on a spoke is defined by the `argocd-hub-read-all` and
+`argocd-hub-deploy` ClusterRoles in `cluster/argocd.tf`. To inspect what is
+actually applied on a spoke:
+
+```bash
+aws eks update-kubeconfig --name <spoke-name>
+
+# The access entry that maps the hub role into the argocd-hub group
+aws eks list-access-entries --cluster-name <spoke-name>
+aws eks describe-access-entry \
+  --cluster-name <spoke-name> \
+  --principal-arn <hub-capability-role-arn>
+
+# The RBAC bound to the argocd-hub group
+kubectl get clusterrole argocd-hub-read-all argocd-hub-deploy
+kubectl describe clusterrole argocd-hub-deploy
+kubectl get clusterrolebinding | grep argocd-hub
+```
+
+To change what the hub may do (for example to allow a new resource kind that a
+workload needs), edit the `argocd-hub-deploy` ClusterRole in `cluster/argocd.tf`
+and apply through the normal PR pipeline. Keep the change least-privilege: add
+only the specific api group, resource, and verbs required. Adding cluster-scoped
+RBAC, CRD, webhook, or node permissions is out of scope for the hub by design,
+and the integration tests will fail if those guardrails are weakened.
+
+### Manage namespaces on a spoke
+
+Namespaces on a spoke are created by GitOps, not by hand. A namespace comes into
+existence when the `app-baseline` chart runs for a product, which also applies
+the default-deny `NetworkPolicy` and the per-namespace `RoleBinding`s.
+
+- To add a namespace, add or update the product definition in the
+  [container-platform-environments](https://github.com/ministryofjustice/container-platform-environments)
+  monorepo so the baseline ApplicationSet renders it.
+- To confirm what is deployed, inspect the spoke:
+
+  ```bash
+  aws eks update-kubeconfig --name <spoke-name>
+  kubectl get namespaces
+  kubectl get networkpolicy -A | grep default-deny
+  kubectl get rolebindings -n <namespace>
+  ```
+
+Avoid creating namespaces with `kubectl` on a spoke. A manually created
+namespace is not tracked in Git and will drift from the desired state.
+
+### Inspect Argo CD on a hub
+
+```bash
+aws eks update-kubeconfig --name <hub-name>
+
+# Registered spokes (one Secret per spoke)
+kubectl -n argocd get secrets -l argocd.argoproj.io/secret-type=cluster
+
+# Applications and their sync/health status
+kubectl -n argocd get applications
+kubectl -n argocd get applicationsets
+kubectl -n argocd describe application <name>
+```
+
+Engineers can also reach the Argo CD UI for a hub by signing in through IAM
+Identity Center (IDC). The level of access depends on the SSO group the signed-in
+user is mapped to:
+
+- **Cloud Platform engineers** sign in with a user mapped to the Argo CD **admin**
+  SSO group, giving full control of Applications and settings.
+- **Application (tenant) engineers** sign in with a user mapped to the Argo CD
+  **read-only** SSO group, so they can view and inspect their Applications and
+  sync status without being able to change them. Their workloads are changed
+  through Git, not directly in the UI.
+
+## Troubleshooting
+
+### Spoke reconcile fails with "failed to verify the access entry"
+
+**Symptom.** Every Application targeting a spoke fails, and the hub logs show
+`failed to verify the access entry` for that cluster.
+
+**Cause.** The EKS-managed Argo CD authenticates to a spoke as the hub's
+**capability role**. If the spoke's access entry was created for a different
+principal (for example a separate spoke-access role), the capability role is not
+recognised and every API call is rejected.
+
+**Fix.** Confirm the spoke has an access entry for the hub's capability role ARN
+and that it maps to the `argocd-hub` group:
+
+```bash
+aws eks list-access-entries --cluster-name <spoke-name>
+aws eks describe-access-entry --cluster-name <spoke-name> \
+  --principal-arn <hub-capability-role-arn>
+```
+
+If the entry is missing or points at the wrong principal, re-apply the spoke's
+Terraform (or correct `argocd_hub_capability_role_arn`) so the capability role
+is registered.
+
+### An Application is stuck with a "forbidden" sync error
+
+**Symptom.** An Application reports a sync error such as
+`... is forbidden: User "..." cannot create resource "..."`.
+
+**Cause.** The resource kind is outside the `argocd-hub-deploy` ClusterRole. The
+hub can only write the workload kinds listed in [Security model](#security-model);
+it cannot write cluster-scoped RBAC, CRDs, webhooks, or nodes.
+
+**Fix.** If the workload legitimately needs a kind that is in scope but not yet
+granted, add that specific api group, resource, and verbs to `argocd-hub-deploy`
+in `cluster/argocd.tf` and apply. If it needs a cluster-scoped or CRD-level
+resource, that is intentionally not permitted for the hub; raise it with the
+platform team rather than widening the role.
+
+### Cluster destroy fails with "Cluster has capabilities attached"
+
+**Symptom.** Destroying a hub fails with
+`ResourceInUseException: Cluster has capabilities attached`.
+
+**Cause.** The Argo CD capability must be removed before the cluster can be
+deleted.
+
+**Fix.** Destroy through the **Development Cluster Deployment** workflow, which
+runs the pre-destroy cleanup in the correct order. Avoid deleting the cluster
+directly.
+
+### Capability creation fails with "trust policy is invalid"
+
+**Symptom.** A fresh hub deploy fails while creating the Argo CD capability,
+citing an invalid trust policy.
+
+**Cause.** IAM role propagation is eventually consistent. The capability role
+was just created and is not yet visible to the capability service. A short
+propagation delay is built into the module, but a slow apply can still hit this.
+
+**Fix.** Re-run the apply. The role will have propagated by the second attempt.
+
+### An ephemeral spoke did not register with its hub
+
+**Symptom.** A dev spoke deploys, but the hub never creates a registration
+Secret or Applications for it.
+
+**Cause.** Ephemeral self-registration relies on the naming convention. The hub
+and spoke must share the same prefix and use the `-hub` and `-spoke` suffixes,
+both must be in the development account, and the spoke must be a
+`development_cluster`.
+
+**Fix.** Check the names match the convention (`cp-1708-2235-hub` pairs with
+`cp-1708-2235-spoke`). If you used non-matching names, pass the hub ARN
+explicitly with `argocd_hub_capability_role_arn` when deploying the spoke.
+
+### The repo server cannot clone from Git
+
+**Symptom.** Applications fail to sync with a repository or authentication error
+against the Git source.
+
+**Cause.** The EKS-managed Argo CD reads Git through AWS CodeConnections using
+the hub's capability role. If the CodeConnections permissions are missing from
+that role, the repo server cannot authenticate.
+
+**Fix.** Confirm the `codeconnection-access` policy is attached to the hub's
+capability role and that the `github-ministryofjustice` CodeConnection is available.
+Re-apply the hub Terraform if the policy is missing.
+
+### `kubectl` reports "you must be logged in to the server"
+
+**Symptom.** `kubectl` commands against a cluster fail mid-session with an
+authentication error.
+
+**Cause.** The token minted by `aws eks update-kubeconfig` has expired, or your
+AWS SSO session has expired.
+
+**Fix.** Refresh your AWS session, then re-run
+`aws eks update-kubeconfig --name <cluster-name>`.
+
+### Integration tests collide with manual Argo CD objects
+
+**Symptom.** The integration test suite fails on a cluster where you have been
+testing by hand.
+
+**Cause.** Manually applied Argo CD objects (AppProjects, cluster Secrets) clash
+with the objects the tests create.
+
+**Fix.** Remove any manually created Argo CD test objects from the cluster before
+running the suite.
+
+## Reference
+
+| Item | Location |
+|------|----------|
+| Hub and spoke Terraform | [modernisation-platform-environments](https://github.com/ministryofjustice/modernisation-platform-environments) `terraform/environments/cloud-platform/cluster/argocd.tf` |
+| Hub GitOps config (AppProjects, ApplicationSets) | `terraform/environments/cloud-platform/cluster-core/argocd-gitops.tf` |
+| Argo CD capability module | `terraform/environments/cloud-platform/cluster/modules/argo-cd/` |
+| Workload manifests | [container-platform-environments](https://github.com/ministryofjustice/container-platform-environments) |
+| RBAC regression tests | [container-platform-integration-tests](https://github.com/ministryofjustice/container-platform-integration-tests) |
+| Deployment workflow | [Development Cluster Deployment](https://github.com/ministryofjustice/cloud-platform-github-workflows/actions/workflows/development-cluster-deploy.yml) |
+| Design decisions | [ADR-002 GitOps Fleet Management](https://github.com/ministryofjustice/cloud-platform/blob/main/architecture-decision-record/cp30/ADR-002-argocd-gitops-fleet-management.md), [ADR-018 Deployment Model Flexibility](https://github.com/ministryofjustice/cloud-platform/blob/main/architecture-decision-record/cp30/ADR-018-deployment-model-flexibility-gitops-vs-push-cd.md) |
+
+### Related pages
+
+- [Create Development Cluster](create-development-cluster.html)
+- [Connecting to CP30 clusters](connecting-to-cp30-clusters.html)
+- [Gateway API](gateway-api.html)

--- a/source/cp30/index.html.md.erb
+++ b/source/cp30/index.html.md.erb
@@ -6,6 +6,7 @@ weight: 10
 # <%= current_page.data.title %>
 This section contains runbooks related to CP30.
 
+- [GitOps with ArgoCD](cp30/gitops-argocd)
 - [Create CP30 test cluster](cp30/create-development-cluster)
 - [Unlock Development Cluster Terraform State](cp30/unlock-development-cluster-terrform-state)
 - [Connecting to CP30 clusters](cp30/connecting-to-cp30-clusters)

--- a/source/images/argocd-hub-spoke.drawio.svg
+++ b/source/images/argocd-hub-spoke.drawio.svg
@@ -1,0 +1,197 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1200" height="940" viewBox="0 0 1200 940" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#37474f"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#2e7d32"/>
+    </marker>
+  </defs>
+  <style>
+    .title { font-size: 22px; font-weight: bold; fill: #102a43; }
+    .subtitle { font-size: 13px; fill: #486581; }
+    .acct { font-size: 13px; font-weight: bold; fill: #b1361e; }
+    .hub { font-size: 14px; font-weight: bold; fill: #0d3c78; }
+    .spoke { font-size: 13px; font-weight: bold; fill: #1b5e20; }
+    .lbl { font-size: 11px; fill: #37474f; }
+    .lblg { font-size: 11px; fill: #2e7d32; }
+    .small { font-size: 10.5px; fill: #52606d; }
+    .tier { font-size: 12px; font-weight: bold; fill: #334e68; }
+  </style>
+
+  <!-- Title -->
+  <text x="600" y="34" text-anchor="middle" class="title">Container Platform 3 — ArgoCD GitOps hub &amp; spoke</text>
+  <text x="600" y="54" text-anchor="middle" class="subtitle">Separate nonlive and live ArgoCD instances deploy to same-tier spoke clusters across AWS accounts</text>
+
+  <!-- GitOps source -->
+  <rect x="450" y="74" width="300" height="60" rx="8" fill="#263238" stroke="#102027" stroke-width="1.5"/>
+  <text x="600" y="99" text-anchor="middle" fill="#ffffff" font-size="13" font-weight="bold">GitHub (GitOps source of truth)</text>
+  <text x="600" y="118" text-anchor="middle" fill="#cfd8dc" font-size="11">ministryofjustice/container-platform-environments</text>
+
+  <!-- Hub account boundary -->
+  <rect x="60" y="170" width="1080" height="180" rx="10" fill="#eef4fb" stroke="#1565c0" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <text x="80" y="192" class="acct">Hub account (management plane)</text>
+
+  <!-- Nonlive hub -->
+  <rect x="120" y="210" width="440" height="120" rx="8" fill="#ffffff" stroke="#1565c0" stroke-width="1.5"/>
+  <text x="340" y="234" text-anchor="middle" class="hub">cloud-platform-nonlive</text>
+  <text x="340" y="253" text-anchor="middle" class="lbl">EKS cluster + EKS-managed ArgoCD capability</text>
+  <text x="340" y="271" text-anchor="middle" class="small">Runs in AWS-managed infrastructure (not on worker nodes)</text>
+  <text x="340" y="289" text-anchor="middle" class="small">Capability role: cloud-platform-nonlive-argocd-capability</text>
+  <text x="340" y="311" text-anchor="middle" fill="#1565c0" font-size="11" font-weight="bold">NONLIVE hub — manages nonlive spokes only</text>
+
+  <!-- Live hub -->
+  <rect x="640" y="210" width="440" height="120" rx="8" fill="#ffffff" stroke="#1565c0" stroke-width="1.5"/>
+  <text x="860" y="234" text-anchor="middle" class="hub">cloud-platform-live</text>
+  <text x="860" y="253" text-anchor="middle" class="lbl">EKS cluster + EKS-managed ArgoCD capability</text>
+  <text x="860" y="271" text-anchor="middle" class="small">Runs in AWS-managed infrastructure (not on worker nodes)</text>
+  <text x="860" y="289" text-anchor="middle" class="small">Capability role: cloud-platform-live-argocd-capability</text>
+  <text x="860" y="311" text-anchor="middle" fill="#1565c0" font-size="11" font-weight="bold">LIVE hub — manages live spokes only</text>
+
+  <!-- Git to hubs -->
+  <path d="M540,134 C440,160 380,180 340,208" fill="none" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <path d="M660,134 C760,160 820,180 860,208" fill="none" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="392" y="166" class="lbl">git pull via CodeConnections</text>
+  <text x="700" y="166" class="lbl">git pull via CodeConnections</text>
+
+  <!-- Deploy arrows hub -> spoke tier -->
+  <path d="M340,330 L340,430" fill="none" stroke="#2e7d32" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <path d="M860,330 L860,430" fill="none" stroke="#2e7d32" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <text x="352" y="368" class="lblg" font-weight="bold">deploy Applications</text>
+  <text x="352" y="384" class="lblg">hub's capability role uses each spoke's</text>
+  <text x="352" y="400" class="lblg">EKS access entry (argocd-hub RBAC)</text>
+  <text x="872" y="368" class="lblg" font-weight="bold">deploy Applications</text>
+  <text x="872" y="384" class="lblg">hub's capability role uses each spoke's</text>
+  <text x="872" y="400" class="lblg">EKS access entry (argocd-hub RBAC)</text>
+
+  <!-- Tier isolation marker -->
+  <path d="M560,270 L640,270" fill="none" stroke="#c62828" stroke-width="1.5" stroke-dasharray="4 4"/>
+  <line x1="588" y1="258" x2="612" y2="282" stroke="#c62828" stroke-width="2"/>
+  <line x1="612" y1="258" x2="588" y2="282" stroke="#c62828" stroke-width="2"/>
+  <text x="600" y="252" text-anchor="middle" fill="#c62828" font-size="10.5" font-weight="bold">tier isolation</text>
+
+  <!-- Nonlive spoke tier -->
+  <rect x="60" y="430" width="520" height="270" rx="10" fill="#f1f8f1" stroke="#2e7d32" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <text x="80" y="452" class="tier">Business-unit spoke accounts — NONLIVE tier</text>
+
+  <!-- Live spoke tier -->
+  <rect x="620" y="430" width="520" height="270" rx="10" fill="#f1f8f1" stroke="#2e7d32" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <text x="640" y="452" class="tier">Business-unit spoke accounts — LIVE tier</text>
+
+  <!-- Nonlive spoke: octo-nonlive -->
+  <rect x="78" y="466" width="158" height="216" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="157" y="487" text-anchor="middle" class="spoke">octo-nonlive</text>
+  <text x="157" y="505" text-anchor="middle" class="small">EKS spoke cluster</text>
+  <text x="157" y="520" text-anchor="middle" class="small">No ArgoCD runs here</text>
+  <rect x="92" y="530" width="130" height="66" rx="4" fill="#e8f5e9" stroke="#a5d6a7"/>
+  <text x="157" y="551" text-anchor="middle" class="small">team namespaces</text>
+  <text x="157" y="566" text-anchor="middle" class="small">+ workloads</text>
+  <text x="157" y="581" text-anchor="middle" class="small">(synced from Git)</text>
+  <text x="157" y="613" text-anchor="middle" class="small">Hub connects via an</text>
+  <text x="157" y="628" text-anchor="middle" class="small">EKS access entry mapped</text>
+  <text x="157" y="643" text-anchor="middle" class="small">to the argocd-hub</text>
+  <text x="157" y="658" text-anchor="middle" class="small">RBAC group</text>
+
+  <!-- Nonlive spoke: laa-nonlive -->
+  <rect x="243" y="466" width="158" height="216" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="322" y="487" text-anchor="middle" class="spoke">laa-nonlive</text>
+  <text x="322" y="505" text-anchor="middle" class="small">EKS spoke cluster</text>
+  <text x="322" y="520" text-anchor="middle" class="small">No ArgoCD runs here</text>
+  <rect x="257" y="530" width="130" height="66" rx="4" fill="#e8f5e9" stroke="#a5d6a7"/>
+  <text x="322" y="551" text-anchor="middle" class="small">team namespaces</text>
+  <text x="322" y="566" text-anchor="middle" class="small">+ workloads</text>
+  <text x="322" y="581" text-anchor="middle" class="small">(synced from Git)</text>
+  <text x="322" y="613" text-anchor="middle" class="small">Hub connects via an</text>
+  <text x="322" y="628" text-anchor="middle" class="small">EKS access entry mapped</text>
+  <text x="322" y="643" text-anchor="middle" class="small">to the argocd-hub</text>
+  <text x="322" y="658" text-anchor="middle" class="small">RBAC group</text>
+
+  <!-- Nonlive spoke: hmpps-nonlive -->
+  <rect x="408" y="466" width="158" height="216" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="487" y="487" text-anchor="middle" class="spoke">hmpps-nonlive</text>
+  <text x="487" y="505" text-anchor="middle" class="small">EKS spoke cluster</text>
+  <text x="487" y="520" text-anchor="middle" class="small">No ArgoCD runs here</text>
+  <rect x="422" y="530" width="130" height="66" rx="4" fill="#e8f5e9" stroke="#a5d6a7"/>
+  <text x="487" y="551" text-anchor="middle" class="small">team namespaces</text>
+  <text x="487" y="566" text-anchor="middle" class="small">+ workloads</text>
+  <text x="487" y="581" text-anchor="middle" class="small">(synced from Git)</text>
+  <text x="487" y="613" text-anchor="middle" class="small">Hub connects via an</text>
+  <text x="487" y="628" text-anchor="middle" class="small">EKS access entry mapped</text>
+  <text x="487" y="643" text-anchor="middle" class="small">to the argocd-hub</text>
+  <text x="487" y="658" text-anchor="middle" class="small">RBAC group</text>
+
+  <!-- Live spoke: octo-live -->
+  <rect x="638" y="466" width="158" height="216" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="717" y="487" text-anchor="middle" class="spoke">octo-live</text>
+  <text x="717" y="505" text-anchor="middle" class="small">EKS spoke cluster</text>
+  <text x="717" y="520" text-anchor="middle" class="small">No ArgoCD runs here</text>
+  <rect x="652" y="530" width="130" height="66" rx="4" fill="#e8f5e9" stroke="#a5d6a7"/>
+  <text x="717" y="551" text-anchor="middle" class="small">team namespaces</text>
+  <text x="717" y="566" text-anchor="middle" class="small">+ workloads</text>
+  <text x="717" y="581" text-anchor="middle" class="small">(synced from Git)</text>
+  <text x="717" y="613" text-anchor="middle" class="small">Hub connects via an</text>
+  <text x="717" y="628" text-anchor="middle" class="small">EKS access entry mapped</text>
+  <text x="717" y="643" text-anchor="middle" class="small">to the argocd-hub</text>
+  <text x="717" y="658" text-anchor="middle" class="small">RBAC group</text>
+
+  <!-- Live spoke: laa-live -->
+  <rect x="803" y="466" width="158" height="216" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="882" y="487" text-anchor="middle" class="spoke">laa-live</text>
+  <text x="882" y="505" text-anchor="middle" class="small">EKS spoke cluster</text>
+  <text x="882" y="520" text-anchor="middle" class="small">No ArgoCD runs here</text>
+  <rect x="817" y="530" width="130" height="66" rx="4" fill="#e8f5e9" stroke="#a5d6a7"/>
+  <text x="882" y="551" text-anchor="middle" class="small">team namespaces</text>
+  <text x="882" y="566" text-anchor="middle" class="small">+ workloads</text>
+  <text x="882" y="581" text-anchor="middle" class="small">(synced from Git)</text>
+  <text x="882" y="613" text-anchor="middle" class="small">Hub connects via an</text>
+  <text x="882" y="628" text-anchor="middle" class="small">EKS access entry mapped</text>
+  <text x="882" y="643" text-anchor="middle" class="small">to the argocd-hub</text>
+  <text x="882" y="658" text-anchor="middle" class="small">RBAC group</text>
+
+  <!-- Live spoke: hmpps-live -->
+  <rect x="968" y="466" width="158" height="216" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="1047" y="487" text-anchor="middle" class="spoke">hmpps-live</text>
+  <text x="1047" y="505" text-anchor="middle" class="small">EKS spoke cluster</text>
+  <text x="1047" y="520" text-anchor="middle" class="small">No ArgoCD runs here</text>
+  <rect x="982" y="530" width="130" height="66" rx="4" fill="#e8f5e9" stroke="#a5d6a7"/>
+  <text x="1047" y="551" text-anchor="middle" class="small">team namespaces</text>
+  <text x="1047" y="566" text-anchor="middle" class="small">+ workloads</text>
+  <text x="1047" y="581" text-anchor="middle" class="small">(synced from Git)</text>
+  <text x="1047" y="613" text-anchor="middle" class="small">Hub connects via an</text>
+  <text x="1047" y="628" text-anchor="middle" class="small">EKS access entry mapped</text>
+  <text x="1047" y="643" text-anchor="middle" class="small">to the argocd-hub</text>
+  <text x="1047" y="658" text-anchor="middle" class="small">RBAC group</text>
+
+  <!-- Dev account -->
+  <rect x="60" y="730" width="760" height="180" rx="10" fill="#fff8e1" stroke="#f9a825" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <text x="80" y="752" class="acct">Development account — ephemeral hub/spoke pairs</text>
+
+  <rect x="110" y="772" width="290" height="110" rx="8" fill="#ffffff" stroke="#1565c0" stroke-width="1.3"/>
+  <text x="255" y="798" text-anchor="middle" class="hub">cp-1708-2235-hub</text>
+  <text x="255" y="817" text-anchor="middle" class="small">enable_argocd = true</text>
+  <text x="255" y="834" text-anchor="middle" class="small">EKS-managed ArgoCD capability</text>
+  <text x="255" y="855" text-anchor="middle" class="small">role: cp-1708-2235-hub-argocd-capability</text>
+
+  <rect x="480" y="772" width="290" height="110" rx="8" fill="#ffffff" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="625" y="798" text-anchor="middle" class="spoke">cp-1708-2235-spoke</text>
+  <text x="625" y="817" text-anchor="middle" class="small">self-registers by "-hub"/"-spoke"</text>
+  <text x="625" y="834" text-anchor="middle" class="small">naming convention (same account)</text>
+  <text x="625" y="855" text-anchor="middle" class="small">access entry mapped to argocd-hub</text>
+
+  <path d="M400,827 L478,827" fill="none" stroke="#2e7d32" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <text x="439" y="818" text-anchor="middle" class="lblg">deploy</text>
+
+  <!-- Legend -->
+  <rect x="840" y="730" width="300" height="180" rx="10" fill="#ffffff" stroke="#90a4ae" stroke-width="1.2"/>
+  <text x="856" y="752" font-size="13" font-weight="bold" fill="#334e68">Key points</text>
+  <text x="856" y="774" class="small">• Two independent ArgoCD instances: nonlive</text>
+  <text x="866" y="789" class="small">and live, each on its own hub cluster.</text>
+  <text x="856" y="808" class="small">• Hub authenticates to spokes as its</text>
+  <text x="866" y="823" class="small">capability role via EKS access entries.</text>
+  <text x="856" y="842" class="small">• No VPC peering / TGW for GitOps traffic;</text>
+  <text x="866" y="857" class="small">cross-account access is native to EKS.</text>
+  <text x="856" y="876" class="small">• Spoke RBAC is least-privilege: cluster</text>
+  <text x="866" y="891" class="small">read + scoped workload write only.</text>
+  <text x="856" y="905" class="small">• A hub only registers spokes in its own tier.</text>
+
+</svg>

--- a/source/images/argocd-repo-structure.drawio.svg
+++ b/source/images/argocd-repo-structure.drawio.svg
@@ -1,0 +1,121 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1200" height="640" viewBox="0 0 1200 640" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arrow2" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#1565c0"/>
+    </marker>
+  </defs>
+  <style>
+    .title { font-size: 21px; font-weight: bold; fill: #102a43; }
+    .subtitle { font-size: 13px; fill: #486581; }
+    .panelh { font-size: 14px; font-weight: bold; fill: #0d3c78; }
+    .mono { font-family: "Courier New", monospace; font-size: 11px; fill: #2d3748; }
+    .monokey { font-family: "Courier New", monospace; font-size: 11px; font-weight: bold; fill: #1b5e20; }
+    .boxh { font-size: 12.5px; font-weight: bold; fill: #0d3c78; }
+    .small { font-size: 10.5px; fill: #52606d; }
+    .flow { font-size: 11px; font-weight: bold; fill: #1565c0; }
+  </style>
+
+  <text x="600" y="32" text-anchor="middle" class="title">GitOps repository structure — what good looks like</text>
+  <text x="600" y="52" text-anchor="middle" class="subtitle">How a product in container-platform-environments maps to ArgoCD ApplicationSets and to resources on a spoke cluster</text>
+
+  <!-- Panel A: repo -->
+  <rect x="30" y="74" width="400" height="548" rx="10" fill="#f7f9fc" stroke="#90a4ae" stroke-width="1.3"/>
+  <text x="45" y="96" class="panelh">1. Source repo (container-platform-environments)</text>
+
+  <text x="45" y="120" class="mono">container-platform-environments/</text>
+  <text x="45" y="135" class="mono">├─ charts/</text>
+  <text x="45" y="150" class="monokey">│  └─ app-baseline/         (baseline chart)</text>
+  <text x="45" y="165" class="mono">│     └─ templates/</text>
+  <text x="45" y="180" class="mono">│        ├─ namespace.yaml</text>
+  <text x="45" y="195" class="mono">│        ├─ rolebinding.yaml</text>
+  <text x="45" y="210" class="mono">│        └─ networkpolicy.yaml</text>
+  <text x="45" y="225" class="mono">└─ namespaces/</text>
+  <text x="45" y="240" class="mono">   └─ octo/                 (business unit)</text>
+  <text x="45" y="255" class="mono">      └─ helloworld/         (product)</text>
+  <text x="45" y="270" class="monokey">         ├─ product.yaml     (envs + access)</text>
+  <text x="45" y="285" class="mono">         ├─ helloworld-api/   (service)</text>
+  <text x="45" y="300" class="mono">         │  └─ deployment/</text>
+  <text x="45" y="315" class="mono">         │     ├─ Chart.yaml</text>
+  <text x="45" y="330" class="mono">         │     ├─ templates/</text>
+  <text x="45" y="345" class="mono">         │     │  ├─ deployment.yaml</text>
+  <text x="45" y="360" class="mono">         │     │  ├─ service.yaml</text>
+  <text x="45" y="375" class="mono">         │     │  └─ httproute.yaml</text>
+  <text x="45" y="390" class="monokey">         │     └─ values/</text>
+  <text x="45" y="405" class="monokey">         │        ├─ nonlive/</text>
+  <text x="45" y="420" class="mono">         │        │  ├─ dev.yaml</text>
+  <text x="45" y="435" class="mono">         │        │  └─ staging.yaml</text>
+  <text x="45" y="450" class="monokey">         │        └─ live/</text>
+  <text x="45" y="465" class="mono">         │           └─ prod.yaml</text>
+  <text x="45" y="480" class="mono">         └─ helloworld-frontend/ (service)</text>
+  <text x="45" y="495" class="mono">            └─ deployment/  (same shape)</text>
+  <text x="45" y="524" class="small">Every business unit and product follows this</text>
+  <text x="45" y="539" class="small">same layout. Highlighted paths drive the two</text>
+  <text x="45" y="554" class="small">ApplicationSets on the right.</text>
+
+  <!-- Panel B: hub ArgoCD -->
+  <rect x="455" y="74" width="340" height="548" rx="10" fill="#eef4fb" stroke="#1565c0" stroke-width="1.3"/>
+  <text x="470" y="96" class="panelh">2. Hub ArgoCD (per business unit)</text>
+
+  <rect x="470" y="112" width="310" height="150" rx="6" fill="#ffffff" stroke="#1565c0" stroke-width="1.2"/>
+  <text x="480" y="133" class="boxh">Baseline ApplicationSet</text>
+  <text x="480" y="152" class="small">generator: git-file-generator</text>
+  <text x="480" y="169" class="small">reads: namespaces/&lt;bu&gt;/*/product.yaml</text>
+  <text x="480" y="186" class="small">renders chart: charts/app-baseline</text>
+  <text x="480" y="207" class="small">creates, per environment:</text>
+  <text x="480" y="224" class="small">• Namespace</text>
+  <text x="480" y="240" class="small">• RoleBinding (from access:)</text>
+  <text x="480" y="256" class="small">• default-deny NetworkPolicy</text>
+
+  <rect x="470" y="278" width="310" height="170" rx="6" fill="#ffffff" stroke="#1565c0" stroke-width="1.2"/>
+  <text x="480" y="299" class="boxh">Workload ApplicationSet</text>
+  <text x="480" y="318" class="small">generator: git-directory-generator</text>
+  <text x="480" y="335" class="small">reads each values file under</text>
+  <text x="480" y="351" class="small">&lt;product&gt;/&lt;service&gt;/deployment/values/&lt;tier&gt;/</text>
+  <text x="480" y="372" class="small">renders that service's deployment chart</text>
+  <text x="480" y="388" class="small">with the selected tier values file</text>
+  <text x="480" y="409" class="small">creates workload objects:</text>
+  <text x="480" y="426" class="small">• Deployment, Service</text>
+  <text x="480" y="442" class="small">• HTTPRoute, HPA, ConfigMap…</text>
+
+  <rect x="470" y="464" width="310" height="92" rx="6" fill="#ffffff" stroke="#1565c0" stroke-width="1.2"/>
+  <text x="480" y="485" class="boxh">AppProject (e.g. octo-nonlive)</text>
+  <text x="480" y="504" class="small">Scopes what those Applications may do:</text>
+  <text x="480" y="521" class="small">allowed source repo, and the destination</text>
+  <text x="480" y="537" class="small">cluster and namespaces they can deploy to.</text>
+
+  <!-- Panel C: spoke result -->
+  <rect x="820" y="74" width="350" height="548" rx="10" fill="#f1f8f1" stroke="#2e7d32" stroke-width="1.3"/>
+  <text x="835" y="96" class="panelh" fill="#1b5e20">3. Result on the spoke (octo-nonlive)</text>
+
+  <rect x="835" y="112" width="320" height="180" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.2"/>
+  <text x="845" y="133" class="boxh" fill="#1b5e20">namespace: helloworld-dev</text>
+  <text x="845" y="155" class="small">baseline (from product.yaml):</text>
+  <text x="845" y="172" class="small">• RoleBinding: cloud-platform → edit</text>
+  <text x="845" y="188" class="small">• default-deny NetworkPolicy</text>
+  <text x="845" y="213" class="small">workloads (from values/nonlive/dev.yaml):</text>
+  <text x="845" y="230" class="small">• helloworld-api: Deployment + Service</text>
+  <text x="845" y="246" class="small">• helloworld-frontend: Deployment + Service</text>
+  <text x="845" y="262" class="small">• HTTPRoute exposes the service</text>
+  <text x="845" y="281" class="small">Namespace isolated from other products.</text>
+
+  <rect x="835" y="308" width="320" height="92" rx="6" fill="#ffffff" stroke="#2e7d32" stroke-width="1.2"/>
+  <text x="845" y="329" class="boxh" fill="#1b5e20">namespace: helloworld-staging</text>
+  <text x="845" y="350" class="small">Same baseline and workloads, rendered</text>
+  <text x="845" y="366" class="small">from values/nonlive/staging.yaml, in its</text>
+  <text x="845" y="382" class="small">own isolated namespace on the same spoke.</text>
+
+  <rect x="835" y="416" width="320" height="140" rx="6" fill="#ffffff" stroke="#90a4ae" stroke-width="1.1"/>
+  <text x="845" y="437" class="boxh">product.yaml maps environments to</text>
+  <text x="845" y="453" class="boxh">a cluster and namespace</text>
+  <text x="845" y="475" class="small">dev → octo-nonlive / helloworld-dev</text>
+  <text x="845" y="491" class="small">staging → octo-nonlive / helloworld-staging</text>
+  <text x="845" y="507" class="small">prod → octo-live / helloworld-prod</text>
+  <text x="845" y="531" class="small">The live tier (prod) is deployed by the</text>
+  <text x="845" y="546" class="small">separate LIVE hub, never the nonlive hub.</text>
+
+  <!-- Flow arrows between panels -->
+  <path d="M433,345 L452,345" fill="none" stroke="#1565c0" stroke-width="2" marker-end="url(#arrow2)"/>
+  <text x="442" y="345" text-anchor="middle" class="flow" transform="rotate(-90 442 345)">reads from Git</text>
+  <path d="M798,345 L817,345" fill="none" stroke="#1565c0" stroke-width="2" marker-end="url(#arrow2)"/>
+  <text x="807" y="345" text-anchor="middle" class="flow" transform="rotate(-90 807 345)">renders &amp; deploys</text>
+</svg>


### PR DESCRIPTION
## What this does

Adds comprehensive, developer-level documentation for the Container Platform 3.0 (CP30) ArgoCD GitOps hub & spoke solution, and begins migrating the CP30 ADRs into this repository.

Closes #8471. Contributes to the docs part of #8438.

## Changes

### New GitOps page (`source/cp30/gitops-argocd.html.md.erb`)
- **Overview** of the EKS-managed ArgoCD model and the separate nonlive/live instances (the subject of #8438).
- **Architecture**: hubs, spokes, capability-role authentication via EKS access entries, the minimal cluster registration Secret, tier isolation, and how workloads flow from Git to spoke namespaces.
- **Repository structure ("what good looks like")**: how a product in `container-platform-environments` (`product.yaml`, `app-baseline`, per-service `deployment/values/<tier>/`) maps through the two ApplicationSets to resources on a spoke.
- **Key features, security model, operational benefits** — including the least-privilege `argocd-hub-read-all` / `argocd-hub-deploy` ClusterRoles and what is deliberately withheld.
- **Runbooks** for platform engineers: a GitHub CLI (`gh`) primer, ephemeral hub/spoke spin-up and tear-down, permanent spoke onboarding, managing the hub-to-spoke RBAC, and namespaces.
- **Troubleshooting** covering seven real failure modes (including the "failed to verify the access entry" issue traced under #8438).
- ArgoCD UI access differentiates Cloud Platform engineers (admin SSO group) from application engineers (read-only SSO group).

### Diagrams
- `argocd-hub-spoke.drawio.svg` — multi-account hub & spoke overview.
- `argocd-repo-structure.drawio.svg` — repo-to-ApplicationSet-to-spoke mapping.
- Both added to `source/images/` (rendered in the docs) and `architecture/container-platform/diagrams/`.

### ADR migration
- New `architecture-decision-record/cp30/` home for CP30 ADRs, with a README explaining the CP2/CP30 split and the independent `ADR-NNN` numbering.
- Migrated **ADR-002** (GitOps Fleet Management) and **ADR-018** (Deployment Model Flexibility) from the design source of truth. More to follow.
- Added a pointer from the CP2 ADR README to the new CP30 log.

### Navigation
- Added a **GitOps with ArgoCD** entry to the CP30 index.

## Notes for reviewers
- No AWS account numbers appear in the docs or diagrams (names/placeholders only).
- The six BU spokes are depicted identically (all BU clusters converge on the same shape).
- Diagrams are hand-authored SVGs; validated as well-formed and rendered for a visual check.